### PR TITLE
On first request to https any domain

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -170,6 +170,7 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
           port: results.openPort,
           server: httpsServer
         }
+        callback(null, results.openPort);
       });
       return 0;
     });


### PR DESCRIPTION
First request to any ssl connection doesn't establish the tunnel due to missing callback call. 
