### PR TITLE
uses the standard library to parse host and port

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,6 +9,7 @@ var fs = require('fs');
 var path = require('path');
 var events = require("events");
 var mkdirps = require('mkdirps');
+var url = require('url');
 
 module.exports = function() {
   return new Proxy();
@@ -433,30 +434,14 @@ Proxy.parseHostAndPort = function(req, defaultPort) {
     req.end("404 - Not Found");
     return null;
   }
-  var hostPort = Proxy.parseHost(host, defaultPort);
-
-  // this handles paths which include the full url. This could happen if it's a proxy
-  var m = req.url.match(/^http:\/\/([^\/]*)\/?(.*)$/);
-  if (m) {
-    hostPort.host = m[1];
-    req.url = '/' + m[2];
-  }
-
-  return hostPort;
+  return Proxy.parseHost(host, defaultPort);
 };
 
 Proxy.parseHost = function(hostString, defaultPort) {
-  var m = hostString.match(/^http:\/\/(.*)/);
-  if (m) {
-    hostString = m[1];
-  }
-
-  var hostPort = hostString.split(':');
-  var host = hostPort[0];
-  var port = hostPort.length === 2 ? +hostPort[1] : defaultPort;
+  var prasedUrl = url.parse(hostString)
 
   return {
-    host: host,
-    port: port
+    host: prasedUrl.hostname,
+    port: prasedUrl.port || defaultPort
   };
 };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -438,7 +438,7 @@ Proxy.parseHostAndPort = function(req, defaultPort) {
 };
 
 Proxy.parseHost = function(hostString, defaultPort) {
-  var prasedUrl = url.parse(hostString)
+  var prasedUrl = url.parse(hostString);
 
   return {
     host: prasedUrl.hostname,


### PR DESCRIPTION
Thanks for your amazing work on this. I'm using it for a research project. I found a little bug where it was failing to proxy the requests of the form `http://user:pass@my_host:port/path` considering `user` as the hostname instead of `my_host`

This should fix it. I've tried it and it seems to work as expected.