### PR TITLE
Host port fix

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -435,14 +435,36 @@ Proxy.parseHostAndPort = function(req, defaultPort) {
     req.end("404 - Not Found");
     return null;
   }
-  return Proxy.parseHost(req.url, defaultPort);
+  var hostPort = Proxy.parseHost(host, defaultPort);
+
+  // this handles paths which include the full url. This could happen if it's a proxy
+  var m = req.url.match(/^http:\/\/([^\/]*)\/?(.*)$/);
+  if (m) {
+    var parsedUrl = url.parse(req.url);
+    hostPort.host = parsedUrl.hostname;
+    hostPort.port = parsedUrl.port;
+    req.url = parsedUrl.path;
+  }
+
+  return hostPort;
 };
 
 Proxy.parseHost = function(hostString, defaultPort) {
-  var parsedUrl = url.parse(hostString);
+  var m = hostString.match(/^http:\/\/(.*)/);
+  if (m) {
+    var parsedUrl = url.parse(req.url);
+    return {
+      host: parsedUrl.hostname,
+      port: parsedUrl.port
+    };
+  }
+
+  var hostPort = hostString.split(':');
+  var host = hostPort[0];
+  var port = hostPort.length === 2 ? +hostPort[1] : defaultPort;
 
   return {
-    host: parsedUrl.hostname,
-    port: parsedUrl.port || defaultPort
+    host: host,
+    port: port
   };
 };


### PR DESCRIPTION
The previous PR caused an unwnated issue, resolved here. The URL parsing is only done when the url is indeed a URL of the form `http*` and skipped when its only of the format `host[:port]`