### PR TITLE
Fixes for issues found by Closure Compiler.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -299,12 +299,10 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     ctx.proxyToServerRequest = proto.request(ctx.proxyToServerRequestOptions, proxyToServerRequestComplete);
     ctx.requestFilters.push(new ProxyFinalRequestFilter(self, ctx));
     var prevRequestPipeElem = ctx.clientToProxyRequest;
-    ctx.requestFilters.forEach(function(filter, i) {
-      prevRequestPipeElem.pipe(filter);
-      prevRequestPipeElem = filter;
+    ctx.requestFilters.forEach(function(filter) {
+      prevRequestPipeElem = prevRequestPipeElem.pipe(filter);
     });
     ctx.clientToProxyRequest.resume();
-    return true;
   }
 
   function proxyToServerRequestComplete(serverToProxyResponse) {
@@ -319,9 +317,8 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, ctx.serverToProxyResponse.headers);
       ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
       var prevResponsePipeElem = ctx.serverToProxyResponse;
-      ctx.responseFilters.forEach(function(filter, i) {
-        prevResponsePipeElem.pipe(filter);
-        prevResponsePipeElem = filter;
+      ctx.responseFilters.forEach(function(filter) {
+        prevResponsePipeElem = prevResponsePipeElem.pipe(filter);
       });
       return ctx.serverToProxyResponse.resume();
     });
@@ -419,6 +416,7 @@ Proxy.prototype._onResponse = function(ctx, callback) {
 };
 
 Proxy.prototype._onResponseData = function(ctx, chunk, callback) {
+  var self = this;
   async.forEach(this.onResponseDataHandlers.concat(ctx.onResponseDataHandlers), function(fn, callback) {
     return fn(ctx, chunk, function(err, newChunk) {
       if (err) {
@@ -438,8 +436,6 @@ Proxy.prototype._onResponseData = function(ctx, chunk, callback) {
 Proxy.parseHostAndPort = function(req, defaultPort) {
   var host = req.headers.host;
   if (!host) {
-    req.writeHead(404);
-    req.end("404 - Not Found");
     return null;
   }
   var hostPort = Proxy.parseHost(host, defaultPort);


### PR DESCRIPTION
The result of a call to pipe() is another stream.Readable, but filter is a stream.Writable.
The returned value 'true' is never used.
http.IncomingMessage is not a stream.Writable.