### PR TITLE
Handle request error (ex: Domain not found errors)

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -516,7 +516,7 @@ var ProxyFinalResponseFilter = function(proxy, ctx) {
           if (err) {
             return proxy._onError(ctx, err);
           }
-          return ctx.proxyToClientResponset.end(chunk);
+          return ctx.proxyToClientResponse.end(chunk);
         });
       });
     } else {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -434,6 +434,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   function makeProxyToServerRequest() {
     var proto = ctx.isSSL ? https : http;
     ctx.proxyToServerRequest = proto.request(ctx.proxyToServerRequestOptions, proxyToServerRequestComplete);
+    ctx.proxyToServerRequest.on('error', self._onError.bind(self, ctx));
     ctx.requestFilters.push(new ProxyFinalRequestFilter(self, ctx));
     var prevRequestPipeElem = ctx.clientToProxyRequest;
     ctx.requestFilters.forEach(function(filter) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -271,6 +271,12 @@ Proxy.prototype._onError = function(ctx, err) {
       return handler(ctx, err);
     });
   }
+  if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.headersSent) {
+    ctx.proxyToClientResponse.writeHead(504, "Proxy Error");
+  }
+  if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.finished) {
+    ctx.proxyToClientResponse.end(""+err, "utf8");
+  }
 };
 
 Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {


### PR DESCRIPTION
For now, proxy to server request errors are not catched and so crash the proxy at the first error, including domain not found errors when the requested host does not exists or is down.
https://github.com/joeferner/node-http-mitm-proxy/issues/18

This pull request:
- catch thoose error in the onError handler
- send a default error response to the client after onError if the response have not been sent yet.
- Fix a typo