### PR TITLE
Handle error event on all requests and responses

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -420,6 +420,8 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     }
   };
 
+  ctx.clientToProxyRequest.on('error', self._onError.bind(self, ctx));
+  ctx.proxyToClientResponse.on('error', self._onError.bind(self, ctx));
   ctx.clientToProxyRequest.pause();
   var hostPort = Proxy.parseHostAndPort(ctx.clientToProxyRequest, ctx.isSSL ? 443 : 80);
   ctx.proxyToServerRequestOptions = {
@@ -450,6 +452,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   }
 
   function proxyToServerRequestComplete(serverToProxyResponse) {
+    serverToProxyResponse.on('error', self._onError.bind(self, ctx));
     serverToProxyResponse.pause();
     ctx.serverToProxyResponse = serverToProxyResponse;
     return self._onResponse(ctx, function(err) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -169,7 +169,8 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
       socket.pipe(conn);
       return conn.pipe(socket);
     });
-  }
+    conn.on('error', self._onError.bind(self, null));
+}
 
   function openHttpsServer(hostname, callback) {
     self.onCertificateRequired(hostname, function (err, files) {
@@ -270,12 +271,13 @@ Proxy.prototype._onError = function(ctx, err) {
     ctx.onErrorHandlers.forEach(function(handler) {
       return handler(ctx, err);
     });
-  }
-  if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.headersSent) {
-    ctx.proxyToClientResponse.writeHead(504, "Proxy Error");
-  }
-  if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.finished) {
-    ctx.proxyToClientResponse.end(""+err, "utf8");
+    
+    if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.headersSent) {
+      ctx.proxyToClientResponse.writeHead(504, "Proxy Error");
+    }
+    if (ctx.proxyToClientResponse && !ctx.proxyToClientResponse.finished) {
+      ctx.proxyToClientResponse.end(""+err, "utf8");
+    }
   }
 };
 


### PR DESCRIPTION
Prevent the proxy server from crashing from any kind of request/response error (like ECONNRESET or whatever that may happen).
Instead it forward the error to onError handlers