### PR TITLE
Use randomly generated CA serial numbers

### DIFF
--- a/lib/ca.js
+++ b/lib/ca.js
@@ -128,11 +128,20 @@ var CA = function (caFolder) {
   this.currentlyGenerating = {};
 };
 
+CA.prototype.randomSerialNumber = function () {
+	// generate random 16 bytes hex string
+	var sn = "";
+	for (var i=0; i<4; i++) {
+		sn += ("00000000" + Math.floor(Math.random()*Math.pow(256, 4)).toString(16)).slice(-8);
+	}
+	return sn;
+}
+
 CA.prototype.generateCA = function () {
   var keys = pki.rsa.generateKeyPair(2048);
   var cert = pki.createCertificate();
   cert.publicKey = keys.publicKey;
-  cert.serialNumber = '01';
+  cert.serialNumber = this.randomSerialNumber();
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date();
   cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 10);
@@ -162,7 +171,7 @@ CA.prototype.generateServerCertificateKeys = function (hostname, cb) {
   var keysServer = pki.rsa.generateKeyPair(1024);
   var certServer = pki.createCertificate();
   certServer.publicKey = keysServer.publicKey;
-  certServer.serialNumber = '02';
+  certServer.serialNumber = this.randomSerialNumber();
   certServer.validity.notBefore = new Date();
   certServer.validity.notAfter = new Date();
   certServer.validity.notAfter.setFullYear(certServer.validity.notBefore.getFullYear() + 2);


### PR DESCRIPTION
Firefox reject server certificate that don't have a unique serial number.
See @VictorBjelkholm comment: https://github.com/joeferner/node-http-mitm-proxy/issues/16#issuecomment-159748949

This pull request fixes this issue by using randomly generated serial number.
