### PR TITLE
Rewrited SSL encryption Resolving

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -141,12 +141,30 @@ Proxy.prototype.use = function(mod) {
 Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
   var self = this;
   
-  // URL is in the form 'hostname:port'
-  var parts = req.url.split(':', 2);
-  var hostname = parts[0];
-  var port = parts[1] || 80;
+  // we need first byte of data to detect if request is SSL encrypted
+  if (!head || head.length === 0) {
+    socket.once('data', function(data) {
+      self._onHttpServerConnect(req, socket, data);
+    });
+    // respond to the client that the connection was made so it can send us data
+    return socket.write("HTTP/1.1 200 OK\r\n\r\n");
+  }
 
-  if (port == 443) {
+  socket.pause();
+
+  // URL is in the form 'hostname:port'
+  var hostname = req.url.split(':', 2)[0];
+
+  /*
+  * Detect TLS from first bytes of data
+  * Inspered from https://gist.github.com/tg-x/835636
+  * used heuristic:
+  * - an incoming connection using SSLv3/TLSv1 records should start with 0x16
+  * - an incoming connection using SSLv2 records should start with the record size
+  *   and as the first record should not be very big we can expect 0x80 or 0x00 (the MSB is a flag)
+  * - everything else is considered to be unencrypted
+  */
+  if (head[0] == 0x16 || head[0] == 0x80 || head[0] == 0x00) {
     var sslServer = this.sslServers[hostname];
     if (sslServer) {
       return makeConnection(sslServer.port);
@@ -165,11 +183,11 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
   function makeConnection(port) {
     // open a TCP connection to the remote host
     var conn = net.connect(port, 'localhost', function() {
-      // respond to the client that the connection was made
-      socket.write("HTTP/1.1 200 OK\r\n\r\n");
       // create a tunnel between the two hosts
       socket.pipe(conn);
-      return conn.pipe(socket);
+      conn.pipe(socket);
+      socket.emit('data', head);
+      return socket.resume();
     });
     conn.on('error', self._onError.bind(self, "PROXY_TO_PROXY_SOCKET_ERROR", null));
   }


### PR DESCRIPTION
Before SSL encryption was guessed with the port of the request which is
not accurate and it caused issues (See #34).
The new resolving process uses the first byte of data to detect SSL,
using an euristic inspired from https://gist.github.com/tg-x/835636

Fixes #34