### PR TITLE
Bug fix in sending back response headres containing white spaces

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -488,7 +488,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       }
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       ctx.serverToProxyResponse.headers['connection'] = 'close';
-      ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, ctx.serverToProxyResponse.headers);
+      ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, canonizeHeaders(ctx.serverToProxyResponse.headers));
       ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
       var prevResponsePipeElem = ctx.serverToProxyResponse;
       ctx.responseFilters.forEach(function(filter) {
@@ -498,6 +498,15 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     });
   }
 };
+
+var canonizeHeaders = function(originalHeaders) {
+  var headers = {};
+  for (var key in originalHeaders) {
+    headers[key.trim()] = originalHeaders[key];
+  }
+
+  return headers;
+}
 
 var ProxyFinalRequestFilter = function(proxy, ctx) {
   events.EventEmitter.call(this);


### PR DESCRIPTION
Some of the response headers may contain white spaces at the beginning or end,
this throws an exception from node native API