### PR TITLE
Add requestEnd event

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -28,6 +28,7 @@ var Proxy = function() {
   this.onWebSocketErrorHandlers = [];
   this.onErrorHandlers = [];
   this.onRequestDataHandlers = [];
+  this.onRequestEndHandlers = [];
   this.onResponseHandlers = [];
   this.onResponseDataHandlers = [];
   this.onResponseEndHandlers = [];
@@ -85,6 +86,10 @@ Proxy.prototype.onWebSocketError = function(fn) {
 
 Proxy.prototype.onRequestData = function(fn) {
   this.onRequestDataHandlers.push(fn);
+};
+
+Proxy.prototype.onRequestEnd = function(fn) {
+  this.onRequestEndHandlers.push(fn);
 };
 
 Proxy.prototype.onResponse = function(fn) {
@@ -399,6 +404,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     onRequestHandlers: [],
     onErrorHandlers: [],
     onRequestDataHandlers: [],
+    onRequestEndHandlers: [],
     onResponseHandlers: [],
     onResponseDataHandlers: [],
     onResponseEndHandlers: [],
@@ -412,6 +418,9 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     },
     onRequestData: function(fn) {
       ctx.onRequestDataHandlers.push(fn);
+    },
+    onRequestEnd: function(fn) {
+      ctx.onRequestEndHandlers.push(fn);
     },
     addRequestFilter: function(filter) {
       ctx.requestFilters.push(filter);
@@ -523,16 +532,12 @@ var ProxyFinalRequestFilter = function(proxy, ctx) {
   };
 
   this.end = function(chunk) {
-    if (chunk) {
-      return proxy._onRequestData(ctx, chunk, function(err, chunk) {
-        if (err) {
-          return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
-        }
-        return ctx.proxyToServerRequest.end(chunk);
-      });
-    } else {
+    return proxy._onRequestEnd(ctx, chunk, function(err, chunk) {
+      if (err) {
+        return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+      }
       return ctx.proxyToServerRequest.end(chunk);
-    }
+    });
   };
 };
 util.inherits(ProxyFinalRequestFilter, events.EventEmitter);
@@ -681,6 +686,24 @@ Proxy.prototype._onWebSocketError = function(ctx, err) {
 Proxy.prototype._onRequestData = function(ctx, chunk, callback) {
   var self = this;
   async.forEach(this.onRequestDataHandlers.concat(ctx.onRequestDataHandlers), function(fn, callback) {
+    return fn(ctx, chunk, function(err, newChunk) {
+      if (err) {
+        return callback(err);
+      }
+      chunk = newChunk;
+      return callback(null, newChunk);
+    });
+  }, function(err) {
+    if (err) {
+      return self._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+    }
+    return callback(null, chunk);
+  });
+};
+
+Proxy.prototype._onRequestEnd = function(ctx, chunk, callback) {
+  var self = this;
+  async.forEach(this.onRequestEndHandlers.concat(ctx.onRequestEndHandlers), function(fn, callback) {
     return fn(ctx, chunk, function(err, newChunk) {
       if (err) {
         return callback(err);


### PR DESCRIPTION
`onRequestEnd` is required to capture the whole request body like so:

    let chunks = [];

    ctx.onRequestData(function(ctx, chunk, callback) {
        chunks.push(chunk);
        return callback(null, chunk);
    });

    ctx.onRequestEnd(function(ctx, chunk, callback) {
        let body = Buffer.concat(chunks)).toString();
        // do something with request body
        return callback(null, chunk);
    });

Fixes #44 