### PR TITLE
modify onRequestEnd to match onResponseEnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Using node-forge allows the automatic generation of SSL certificates within the 
  * [onCertificateMissing](#proxy_onCertificateMissing)
  * [onRequest(fn)](#proxy_onRequest)
  * [onRequestData(fn)](#proxy_onRequestData)
+ * [onRequestEnd(fn)](#proxy_onRequestEnd)
  * [onResponse(fn)](#proxy_onResponse)
  * [onResponseData(fn)](#proxy_onResponseData)
+ * [onResponseEnd(fn)](#proxy_onResponseEnd)
  * [onWebSocketConnection(fn)](#proxy_onWebSocketConnection)
  * [onWebSocketSend(fn)](#proxy_onWebSocketSend)
  * [onWebSocketMessage(fn)](#proxy_onWebSocketMessage)
@@ -71,10 +73,11 @@ Using node-forge allows the automatic generation of SSL certificates within the 
  * [onError(fn)](#proxy_onError)
  * [onRequest(fn)](#proxy_onRequest)
  * [onRequestData(fn)](#proxy_onRequestData)
+ * [onRequestEnd(fn)](#proxy_onRequestEnd)
  * [addRequestFilter(fn)](#context_addRequestFilter)
  * [onResponse(fn)](#proxy_onResponse)
  * [onResponseData(fn)](#proxy_onResponseData)
- * [onResponseEnd(fn)](#context_onResponseEnd)
+ * [onResponseEnd(fn)](#proxy_onResponseEnd)
  * [addResponseFilter(fn)](#context_addResponseFilter)
  * [use(mod)](#proxy_use)
 
@@ -211,6 +214,29 @@ __Example__
       return callback(null, chunk);
     });
 
+<a name="proxy_onRequestEnd" />
+### proxy.onRequestEnd(fn) or ctx.onRequestEnd(fn)
+
+Adds a function to get called when all request data (the body) was sent.
+
+__Arguments__
+
+ * fn(ctx, callback) - The function that gets called when all request data (the body) was sent.
+
+__Example__
+
+    var chunks = [];
+    
+    proxy.onRequestData(function(ctx, chunk, callback) {
+      chunks.push(chunk);
+      return callback(null, chunk);
+    });
+
+    proxy.onRequestEnd(function(ctx, callback) {
+      console.log('REQUEST END', (Buffer.concat(chunks)).toString());
+      return callback();
+    });
+
 <a name="proxy_onResponse" />
 ### proxy.onResponse(fn) or ctx.onResponse(fn)
 
@@ -241,6 +267,22 @@ __Example__
     proxy.onResponseData(function(ctx, chunk, callback) {
       console.log('RESPONSE DATA:', chunk.toString());
       return callback(null, chunk);
+    });
+
+<a name="proxy_onResponseEnd" />
+### proxy.onResponseEnd(fn) or ctx.onResponseEnd(fn)
+
+Adds a function to get called when the proxy request to server has ended.
+
+__Arguments__
+
+ * fn(ctx, callback) - The function that gets called when the proxy request to server as ended.
+
+__Example__
+
+    proxy.onResponseEnd(function(ctx, callback) {
+      console.log('RESPONSE END', chunk.toString());
+      return callback();
     });
 
 <a name="proxy_onWebSocketConnection" />
@@ -376,22 +418,6 @@ __Arguments__
 __Example__
 
     ctx.addResponseFilter(zlib.createGunzip());
-
-<a name="context_onResponseEnd" />
-### ctx.onResponseEnd(fn)
-
-Adds a function to get called when the proxy request to server as ended.
-
-__Arguments__
-
- * fn(ctx, callback) - The function that gets called when the proxy request to server as ended.
-
-__Example__
-
-    proxy.onResponseEnd(function(ctx, callback) {
-      console.log('RESPONSE END', chunk.toString());
-      return callback();
-    });
 
 # License
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -532,12 +532,27 @@ var ProxyFinalRequestFilter = function(proxy, ctx) {
   };
 
   this.end = function(chunk) {
-    return proxy._onRequestEnd(ctx, chunk, function(err, chunk) {
-      if (err) {
-        return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
-      }
-      return ctx.proxyToServerRequest.end(chunk);
-    });
+    if (chunk) {
+      return proxy._onRequestData(ctx, chunk, function(err, chunk) {
+        if (err) {
+          return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+        }
+
+        return proxy._onRequestEnd(ctx, function (err) {
+          if (err) {
+            return proxy._onError("ON_REQUEST_END_ERROR", ctx, err);
+          }
+          return ctx.proxyToServerRequest.end(chunk);
+        });
+      });
+    } else {
+      return proxy._onRequestEnd(ctx, function (err) {
+        if (err) {
+          return proxy._onError("ON_REQUEST_END_ERROR", ctx, err);
+        }
+        return ctx.proxyToServerRequest.end(chunk || undefined);
+      });
+    }
   };
 };
 util.inherits(ProxyFinalRequestFilter, events.EventEmitter);
@@ -701,21 +716,15 @@ Proxy.prototype._onRequestData = function(ctx, chunk, callback) {
   });
 };
 
-Proxy.prototype._onRequestEnd = function(ctx, chunk, callback) {
+Proxy.prototype._onRequestEnd = function(ctx, callback) {
   var self = this;
   async.forEach(this.onRequestEndHandlers.concat(ctx.onRequestEndHandlers), function(fn, callback) {
-    return fn(ctx, chunk, function(err, newChunk) {
-      if (err) {
-        return callback(err);
-      }
-      chunk = newChunk;
-      return callback(null, newChunk);
-    });
+    return fn(ctx, callback);
   }, function(err) {
     if (err) {
-      return self._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+      return self._onError("ON_REQUEST_END_ERROR", ctx, err);
     }
-    return callback(null, chunk);
+    return callback(null);
   });
 };
 


### PR DESCRIPTION
Small changes to my yesterday's PR:

- I changed `onRequestEnd` signature (`ctx, chunk, callback` :arrow_right: `ctx, callback`) to match `onResponseEnd` because:
  - it makes API more consistent and
  - unlike previous version (where last chunk went to `onRequestEnd`) this is a non-breaking change (all chunks go to `onRequestData` as before)
- I've also updated the docs:
  - `onRequestEnd` was added and
  - `onResponseEnd` was updated (docs suggested that it's available only on `ctx` while it was also available on `proxy` + there was a minor typo ("as" :arrow_right: "has")).