### PR TITLE
Add methods / Expose Proxy to allow inherintance

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -140,6 +140,9 @@ Proxy.prototype.use = function(mod) {
   if (mod.onResponse) {
     this.onResponse(mod.onResponse);
   }
+  if (mod.onResponseHeaders) {
+    this.onResponseHeaders(mod.onResponseHeaders);
+  }
   if (mod.onResponseData) {
     this.onResponseData(mod.onResponseData);
   }
@@ -534,7 +537,6 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
         });
         return ctx.serverToProxyResponse.resume();
       });
-      
     });
   }
 };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -17,10 +17,13 @@ module.exports = function() {
   return new Proxy();
 };
 
+
+
 module.exports.gunzip = require('./middleware/gunzip');
 
 var Proxy = function() {
   this.onRequestHandlers = [];
+  this.onRequestHeadersHandlers = [];
   this.onWebSocketConnectionHandlers = [];
   this.onWebSocketSendHandlers = [];
   this.onWebSocketMessageHandlers = [];
@@ -30,9 +33,12 @@ var Proxy = function() {
   this.onRequestDataHandlers = [];
   this.onRequestEndHandlers = [];
   this.onResponseHandlers = [];
+  this.onResponseHeadersHandlers = [];
   this.onResponseDataHandlers = [];
   this.onResponseEndHandlers = [];
 };
+
+module.exports.Proxy = Proxy;
 
 Proxy.prototype.listen = function(options) {
   var self = this;
@@ -58,6 +64,10 @@ Proxy.prototype.listen = function(options) {
 
 Proxy.prototype.onError = function(fn) {
   this.onErrorHandlers.push(fn);
+};
+
+Proxy.prototype.onRequestHeaders = function(fn) {
+  this.onRequestHeadersHandlers.push(fn);
 };
 
 Proxy.prototype.onRequest = function(fn) {
@@ -96,6 +106,10 @@ Proxy.prototype.onResponse = function(fn) {
   this.onResponseHandlers.push(fn);
 };
 
+Proxy.prototype.onResponseHeaders = function(fn) {
+  this.onResponseHeadersHandlers.push(fn);
+};
+
 Proxy.prototype.onResponseData = function(fn) {
   this.onResponseDataHandlers.push(fn);
 };
@@ -116,6 +130,9 @@ Proxy.prototype.use = function(mod) {
   }
   if (mod.onRequest) {
     this.onRequest(mod.onRequest);
+  }
+  if (mod.onRequestHeaders) {
+    this.onRequestHeaders(mod.onRequestHeaders);
   }
   if (mod.onRequestData) {
     this.onRequestData(mod.onRequestData);
@@ -444,6 +461,9 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       if (mod.onRequest) {
         ctx.onRequest(mod.onRequest);
       }
+      if (mod.onRequestHeaders) {
+        ctx.onRequestHeaders(mod.onRequestHeaders);
+      }
       if (mod.onRequestData) {
         ctx.onRequestData(mod.onRequestData);
       }
@@ -472,7 +492,12 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     if (err) {
       return self._onError("ON_REQUEST_ERROR", ctx, err);
     }
-    return makeProxyToServerRequest();
+    return self._onRequestHeaders({ client: ctx.proxyToServerRequestOptions }, function(err) {
+      if (err) {
+        return self._onError("ON_REQUESTHEADERS_ERROR", ctx, err);
+      }
+      return makeProxyToServerRequest();
+    });
   });
 
   function makeProxyToServerRequest() {
@@ -497,13 +522,19 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       }
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       ctx.serverToProxyResponse.headers['connection'] = 'close';
-      ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, canonizeHeaders(ctx.serverToProxyResponse.headers));
-      ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
-      var prevResponsePipeElem = ctx.serverToProxyResponse;
-      ctx.responseFilters.forEach(function(filter) {
-        prevResponsePipeElem = prevResponsePipeElem.pipe(filter);
+      return self._onResponseHeaders({ client: ctx.proxyToServerRequestOptions, server: ctx.serverToProxyResponse }, function (err) {
+        if (err) {
+          return self._onError("ON_RESPONSEHEADERS_ERROR", ctx, err);
+        }
+        ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, canonizeHeaders(ctx.serverToProxyResponse.headers));
+        ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
+        var prevResponsePipeElem = ctx.serverToProxyResponse;
+        ctx.responseFilters.forEach(function(filter) {
+          prevResponsePipeElem = prevResponsePipeElem.pipe(filter);
+        });
+        return ctx.serverToProxyResponse.resume();
       });
-      return ctx.serverToProxyResponse.resume();
+      
     });
   }
 };
@@ -526,7 +557,9 @@ var ProxyFinalRequestFilter = function(proxy, ctx) {
       if (err) {
         return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
       }
-      return ctx.proxyToServerRequest.write(chunk);
+      if (chunk) {
+        return ctx.proxyToServerRequest.write(chunk);
+      }
     });
     return true;
   };
@@ -600,6 +633,12 @@ var ProxyFinalResponseFilter = function(proxy, ctx) {
   return this;
 };
 util.inherits(ProxyFinalResponseFilter, events.EventEmitter);
+
+Proxy.prototype._onRequestHeaders = function(ctx, callback) {
+  async.forEach(this.onRequestHeadersHandlers, function(fn, callback) {
+    return fn(ctx, callback);
+  }, callback);
+};
 
 Proxy.prototype._onRequest = function(ctx, callback) {
   async.forEach(this.onRequestHandlers.concat(ctx.onRequestHandlers), function(fn, callback) {
@@ -730,6 +769,12 @@ Proxy.prototype._onRequestEnd = function(ctx, callback) {
 
 Proxy.prototype._onResponse = function(ctx, callback) {
   async.forEach(this.onResponseHandlers.concat(ctx.onResponseHandlers), function(fn, callback) {
+    return fn(ctx, callback);
+  }, callback);
+};
+
+Proxy.prototype._onResponseHeaders = function(ctx, callback) {
+  async.forEach(this.onResponseHeadersHandlers, function(fn, callback) {
     return fn(ctx, callback);
   }, callback);
 };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -495,7 +495,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     if (err) {
       return self._onError("ON_REQUEST_ERROR", ctx, err);
     }
-    return self._onRequestHeaders({ client: ctx.proxyToServerRequestOptions }, function(err) {
+    return self._onRequestHeaders(ctx, function(err) {
       if (err) {
         return self._onError("ON_REQUESTHEADERS_ERROR", ctx, err);
       }
@@ -525,7 +525,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       }
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       ctx.serverToProxyResponse.headers['connection'] = 'close';
-      return self._onResponseHeaders({ client: ctx.proxyToServerRequestOptions, server: ctx.serverToProxyResponse }, function (err) {
+      return self._onResponseHeaders(ctx, function (err) {
         if (err) {
           return self._onError("ON_RESPONSEHEADERS_ERROR", ctx, err);
         }


### PR DESCRIPTION
Added onRequestHeaders and onResponseHeaders, to ease interception and modification of headers before relayed on.

added exports.Proxy = Proxy so that one can use the object as a base for other objects.