### PR TITLE
Allow method chaining

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -60,6 +60,7 @@ Proxy.prototype.listen = function(options) {
     self.wsServer.on('connection', self._onWebSocketServerConnect.bind(self, false));
     self.httpServer.listen(self.httpPort);
   });
+  return this;
 };
 
 Proxy.prototype.close = function () {
@@ -69,62 +70,77 @@ Proxy.prototype.close = function () {
     self.sslServers[srvName].server.close();
     delete self.sslServers[srvName];
   });
+  return this;
 };
 
 Proxy.prototype.onError = function(fn) {
   this.onErrorHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onRequestHeaders = function(fn) {
   this.onRequestHeadersHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onRequest = function(fn) {
   this.onRequestHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onWebSocketConnection = function(fn) {
   this.onWebSocketConnectionHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onWebSocketSend = function(fn) {
   this.onWebSocketSendHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onWebSocketMessage = function(fn) {
   this.onWebSocketMessageHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onWebSocketClose = function(fn) {
   this.onWebSocketCloseHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onWebSocketError = function(fn) {
   this.onWebSocketErrorHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onRequestData = function(fn) {
   this.onRequestDataHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onRequestEnd = function(fn) {
   this.onRequestEndHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onResponse = function(fn) {
   this.onResponseHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onResponseHeaders = function(fn) {
   this.onResponseHeadersHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onResponseData = function(fn) {
   this.onResponseDataHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.onResponseEnd = function(fn) {
   this.onResponseEndHandlers.push(fn);
+  return this;
 };
 
 Proxy.prototype.use = function(mod) {
@@ -170,6 +186,7 @@ Proxy.prototype.use = function(mod) {
   if (mod.onWebSocketError) {
     this.onWebSocketError(mod.onWebSocketError);
   }
+  return this;
 };
 
 Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
@@ -312,6 +329,7 @@ Proxy.prototype.onCertificateRequired = function (hostname, callback) {
     keyFile: self.sslCaDir + '/keys/' + hostname + '.key',
     certFile: self.sslCaDir + '/certs/' + hostname + '.pem'
   });
+  return this;
 };
 Proxy.prototype.onCertificateMissing = function (ctx, files, callback) {
   this.ca.getServerCertificateKeys(ctx.hostname, function (certPEM, privateKeyPEM) {
@@ -320,6 +338,7 @@ Proxy.prototype.onCertificateMissing = function (ctx, files, callback) {
       keyFileData: privateKeyPEM
     });
   });
+  return this;
 };
 
 Proxy.prototype._onError = function(kind, ctx, err) {
@@ -441,30 +460,39 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     responseFilters: [],
     onRequest: function(fn) {
       ctx.onRequestHandlers.push(fn);
+      return ctx;
     },
     onError: function(fn) {
       ctx.onErrorHandlers.push(fn);
+      return ctx;
     },
     onRequestData: function(fn) {
       ctx.onRequestDataHandlers.push(fn);
+      return ctx;
     },
     onRequestEnd: function(fn) {
       ctx.onRequestEndHandlers.push(fn);
+      return ctx;
     },
     addRequestFilter: function(filter) {
       ctx.requestFilters.push(filter);
+      return ctx;
     },
     onResponse: function(fn) {
       ctx.onResponseHandlers.push(fn);
+      return ctx;
     },
     onResponseData: function(fn) {
       ctx.onResponseDataHandlers.push(fn);
+      return ctx;
     },
     onResponseEnd: function(fn) {
       ctx.onResponseEndHandlers.push(fn);
+      return ctx;
     },
     addResponseFilter: function(filter) {
       ctx.responseFilters.push(filter);
+      return ctx;
     },
     use: function(mod) {
       if (mod.onError) {
@@ -485,6 +513,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       if (mod.onResponseData) {
         ctx.onResponseData(mod.onResponseData);
       }
+      return ctx;
     }
   };
 


### PR DESCRIPTION
Allows to write
```
proxy.onRequest(handleIncomingRequest.bind(this))
     .onResponse(handleIncomingResponse.bind(this))
     .onError(handleProxyError.bind(this))
     .listen({port: port});
```

instead of:
```
  proxy.onRequest(handleIncomingRequest.bind(this));
  proxy.onResponse(handleIncomingResponse.bind(this));
  proxy.onError(handleProxyError.bind(this));
  proxy.listen({port: port});
```

same for context

Fix #43