### PR TITLE
Websocket ping pong

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Using node-forge allows the automatic generation of SSL certificates within the 
  * [onWebSocketConnection(fn)](#proxy_onWebSocketConnection)
  * [onWebSocketSend(fn)](#proxy_onWebSocketSend)
  * [onWebSocketMessage(fn)](#proxy_onWebSocketMessage)
+ * [onWebSocketFrame(fn)](#proxy_onWebSocketFrame)
  * [onWebSocketError(fn)](#proxy_onWebSocketError)
  * [onWebSocketClose(fn)](#proxy_onWebSocketClose)
  * [use(fn)](#proxy_use)
@@ -92,6 +93,7 @@ The context available in websocket handlers is a bit different
  * [onWebSocketConnection(fn)](#proxy_onWebSocketConnection)
  * [onWebSocketSend(fn)](#proxy_onWebSocketSend)
  * [onWebSocketMessage(fn)](#proxy_onWebSocketMessage)
+ * [onWebSocketFrame(fn)](#proxy_onWebSocketFrame)
  * [onWebSocketError(fn)](#proxy_onWebSocketError)
  * [onWebSocketClose(fn)](#proxy_onWebSocketClose)
  * [use(mod)](#proxy_use)
@@ -340,6 +342,22 @@ __Example__
 
     proxy.onWebSocketMessage(function(ctx, message, flags, callback) {
       console.log('WEBSOCKET MESSAGE:', ctx.clientToProxyWebSocket.upgradeReq.url, message);
+      return callback(null, message, flags);
+    });
+
+<a name="proxy_onWebSocketFrame" />
+### proxy.onWebSocketFrame(fn) or ctx.onWebSocketFrame(fn)
+
+Adds a function to get called for each WebSocket frame exchanged (`message`, `ping` or `pong`).
+
+__Arguments__
+
+ * fn(ctx, type, fromServer, data, flags, callback) - The function that gets called for each WebSocket frame exchanged.
+
+__Example__
+
+    proxy.onWebSocketFrame(function(ctx, type, fromServer, data, flags, callback) {
+      console.log('WEBSOCKET FRAME ' + type + ' received from ' + (fromServer ? 'server' : 'client'), ctx.clientToProxyWebSocket.upgradeReq.url, message);
       return callback(null, message, flags);
     });
 

--- a/examples/websocket.js
+++ b/examples/websocket.js
@@ -14,15 +14,10 @@ proxy.onWebSocketConnection(function(ctx, callback) {
   console.log('WEBSOCKET CONNECT:', ctx.clientToProxyWebSocket.upgradeReq.url);
   return callback();
 });
-proxy.onWebSocketSend(function(ctx, message, flags, callback) {
-  console.log('WEBSOCKET SEND:', ctx.clientToProxyWebSocket.upgradeReq.url, message);
-  var hackedMessage = message.replace(/Rock it/ig, "Hack it");
-  return callback(null, hackedMessage, flags);
-});
-proxy.onWebSocketMessage(function(ctx, message, flags, callback) {
-  console.log('WEBSOCKET MESSAGE ', ctx.clientToProxyWebSocket.upgradeReq.url, message);
-  var hackedMessage = message.replace(/Rock it/ig, "Hack it");
-  return callback(null, hackedMessage, flags);
+proxy.onWebSocketFrame(function(ctx, type, fromServer, message, flags, callback) {
+  console.log('WEBSOCKET FRAME ' + type + ' received from ' + (fromServer ? 'server' : 'client'), ctx.clientToProxyWebSocket.upgradeReq.url, message);
+  if (message) var hackedMessage = message.replace(/Rock it/ig, "Hack it");
+  return callback(null, message, flags);
 });
 proxy.onWebSocketError(function(ctx, err) {
   console.log('WEBSOCKET ERROR ', ctx.clientToProxyWebSocket.upgradeReq.url, err);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -389,27 +389,33 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
     onWebSocketErrorHandlers: [],
     onWebSocketConnection: function(fn) {
       ctx.onWebSocketConnectionHandlers.push(fn);
+      return ctx;
     },
     onWebSocketSend: function(fn) {
       ctx.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
         if (!fromServer && type === 'message') return this(data, flags, callback);
 	    else callback(null, data, flags);
       }.bind(fn));
+      return ctx;
     },
     onWebSocketMessage: function(fn) {
       ctx.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
         if (fromServer && type === 'message') return this(data, flags, callback);
 	    else callback(null, data, flags);
       }.bind(fn));
+      return ctx;
     },
     onWebSocketFrame: function(fn) {
       ctx.onWebSocketFrameHandlers.push(fn);
+      return ctx;
     },
     onWebSocketClose: function(fn) {
       ctx.onWebSocketCloseHandlers.push(fn);
+      return ctx;
     },
     onWebSocketError: function(fn) {
       ctx.onWebSocketErrorHandlers.push(fn);
+      return ctx;
     },
     use: function(mod) {
       if (mod.onWebSocketConnection) {
@@ -436,6 +442,7 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
       if (mod.onWebSocketError) {
         ctx.onWebSocketError(mod.onWebSocketError);
       }
+      return ctx;
     }
   };
   ctx.clientToProxyWebSocket.on('message', self._onWebSocketFrame.bind(self, ctx, 'message', false));

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -25,8 +25,7 @@ var Proxy = function() {
   this.onRequestHandlers = [];
   this.onRequestHeadersHandlers = [];
   this.onWebSocketConnectionHandlers = [];
-  this.onWebSocketSendHandlers = [];
-  this.onWebSocketMessageHandlers = [];
+  this.onWebSocketFrameHandlers = [];
   this.onWebSocketCloseHandlers = [];
   this.onWebSocketErrorHandlers = [];
   this.onErrorHandlers = [];
@@ -94,12 +93,23 @@ Proxy.prototype.onWebSocketConnection = function(fn) {
 };
 
 Proxy.prototype.onWebSocketSend = function(fn) {
-  this.onWebSocketSendHandlers.push(fn);
+  this.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
+    if (!fromServer && type === 'message') return this(data, flags, callback);
+	else callback(null, data, flags);
+  }.bind(fn));
   return this;
 };
 
 Proxy.prototype.onWebSocketMessage = function(fn) {
-  this.onWebSocketMessageHandlers.push(fn);
+  this.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
+    if (fromServer && type === 'message') return this(data, flags, callback);
+	else callback(null, data, flags);
+  }.bind(fn));
+  return this;
+};
+
+Proxy.prototype.onWebSocketFrame = function(fn) {
+  this.onWebSocketFrameHandlers.push(fn);
   return this;
 };
 
@@ -175,10 +185,19 @@ Proxy.prototype.use = function(mod) {
     this.onWebSocketConnection(mod.onWebSocketConnection);
   }
   if (mod.onWebSocketSend) {
-    this.onWebSocketSend(mod.onWebSocketSend);
+    this.onWebSocketFrame(function(ctx, type, fromServer, data, flags, callback) {
+      if (!fromServer && type === 'message') return this(data, flags, callback);
+	  else callback(null, data, flags);
+    }.bind(mod.onWebSocketSend));
   }
   if (mod.onWebSocketMessage) {
-    this.onWebSocketMessage(mod.onWebSocketMessage);
+    this.onWebSocketFrame(function(ctx, type, fromServer, data, flags, callback) {
+      if (fromServer && type === 'message') return this(data, flags, callback);
+	  else callback(null, data, flags);
+    }.bind(mod.onWebSocketMessage));
+  }
+  if (mod.onWebSocketFrame) {
+    this.onWebSocketFrame(mod.onWebSocketFrame);
   }
   if (mod.onWebSocketClose) {
     this.onWebSocketClose(mod.onWebSocketClose);
@@ -365,18 +384,26 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
     isSSL: isSSL,
     clientToProxyWebSocket: ws,
     onWebSocketConnectionHandlers: [],
-    onWebSocketSendHandlers: [],
-    onWebSocketMessageHandlers: [],
+    onWebSocketFrameHandlers: [],
     onWebSocketCloseHandlers: [],
     onWebSocketErrorHandlers: [],
     onWebSocketConnection: function(fn) {
       ctx.onWebSocketConnectionHandlers.push(fn);
     },
     onWebSocketSend: function(fn) {
-      ctx.onWebSocketSendHandlers.push(fn);
+      ctx.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
+        if (!fromServer && type === 'message') return this(data, flags, callback);
+	    else callback(null, data, flags);
+      }.bind(fn));
     },
     onWebSocketMessage: function(fn) {
-      ctx.onWebSocketMessageHandlers.push(fn);
+      ctx.onWebSocketFrameHandlers.push(function(ctx, type, fromServer, data, flags, callback) {
+        if (fromServer && type === 'message') return this(data, flags, callback);
+	    else callback(null, data, flags);
+      }.bind(fn));
+    },
+    onWebSocketFrame: function(fn) {
+      ctx.onWebSocketFrameHandlers.push(fn);
     },
     onWebSocketClose: function(fn) {
       ctx.onWebSocketCloseHandlers.push(fn);
@@ -389,10 +416,19 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
         ctx.onWebSocketConnection(mod.onWebSocketConnection);
       }
       if (mod.onWebSocketSend) {
-        ctx.onWebSocketSend(mod.onWebSocketSend);
+        ctx.onWebSocketFrame(function(ctx, type, fromServer, data, flags, callback) {
+          if (!fromServer && type === 'message') return this(data, flags, callback);
+	      else callback(null, data, flags);
+        }.bind(mod.onWebSocketSend));
       }
       if (mod.onWebSocketMessage) {
-        ctx.onWebSocketMessage(mod.onWebSocketMessage);
+        ctx.onWebSocketFrame(function(ctx, type, fromServer, data, flags, callback) {
+          if (fromServer && type === 'message') return this(data, flags, callback);
+	      else callback(null, data, flags);
+        }.bind(mod.onWebSocketMessage));
+      }
+      if (mod.onWebSocketFrame) {
+        ctx.onWebSocketFrame(mod.onWebSocketFrame);
       }
       if (mod.onWebSocketClose) {
         ctx.onWebSocketClose(mod.onWebSocketClose);
@@ -402,7 +438,9 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
       }
     }
   };
-  ctx.clientToProxyWebSocket.on('message', self._onWebSocketSend.bind(self, ctx));
+  ctx.clientToProxyWebSocket.on('message', self._onWebSocketFrame.bind(self, ctx, 'message', false));
+  ctx.clientToProxyWebSocket.on('ping', self._onWebSocketFrame.bind(self, ctx, 'ping', false));
+  ctx.clientToProxyWebSocket.on('pong', self._onWebSocketFrame.bind(self, ctx, 'pong', false));
   ctx.clientToProxyWebSocket.on('error', self._onWebSocketError.bind(self, ctx));
   ctx.clientToProxyWebSocket.on('close', self._onWebSocketClose.bind(self, ctx, false));
   ctx.clientToProxyWebSocket.pause();
@@ -434,7 +472,9 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
 
   function makeProxyToServerWebSocket() {
     ctx.proxyToServerWebSocket = new WebSocket(ctx.proxyToServerWebSocketOptions.url, ctx.proxyToServerWebSocketOptions);
-    ctx.proxyToServerWebSocket.on('message', self._onWebSocketMessage.bind(self, ctx));
+    ctx.proxyToServerWebSocket.on('message', self._onWebSocketFrame.bind(self, ctx, 'message', true));
+    ctx.proxyToServerWebSocket.on('ping', self._onWebSocketFrame.bind(self, ctx, 'ping', true));
+    ctx.proxyToServerWebSocket.on('pong', self._onWebSocketFrame.bind(self, ctx, 'pong', true));
     ctx.proxyToServerWebSocket.on('error', self._onWebSocketError.bind(self, ctx));
     ctx.proxyToServerWebSocket.on('close', self._onWebSocketClose.bind(self, ctx, true));
     ctx.proxyToServerWebSocket.on('open', function() {
@@ -692,10 +732,10 @@ Proxy.prototype._onWebSocketConnection = function(ctx, callback) {
   }, callback);
 };
 
-Proxy.prototype._onWebSocketSend = function(ctx, data, flags) {
+Proxy.prototype._onWebSocketFrame = function(ctx, type, fromServer, data, flags) {
   var self = this;
-  async.forEach(this.onWebSocketSendHandlers.concat(ctx.onWebSocketSendHandlers), function(fn, callback) {
-    return fn(ctx, data, flags, function(err, newData, newFlags) {
+  async.forEach(this.onWebSocketFrameHandlers.concat(ctx.onWebSocketFrameHandlers), function(fn, callback) {
+    return fn(ctx, type, fromServer, data, flags, function(err, newData, newFlags) {
       if (err) {
         return callback(err);
       }
@@ -707,33 +747,18 @@ Proxy.prototype._onWebSocketSend = function(ctx, data, flags) {
     if (err) {
       return self._onWebSocketError(ctx, err);
     }
-    if (ctx.proxyToServerWebSocket.readyState === WebSocket.OPEN) {
-      ctx.proxyToServerWebSocket.send(data, flags);
-    } else {
-      self._onWebSocketError(ctx, new Error("Cannot send message because proxyToServer WebSocket connection state is not OPEN"));
-    }
-  });
-};
-
-Proxy.prototype._onWebSocketMessage = function(ctx, data, flags) {
-  var self = this;
-  async.forEach(this.onWebSocketMessageHandlers.concat(ctx.onWebSocketMessageHandlers), function(fn, callback) {
-    return fn(ctx, data, flags, function(err, newData, newFlags) {
-      if (err) {
-        return callback(err);
+    var destWebSocket = fromServer ? ctx.clientToProxyWebSocket : ctx.proxyToServerWebSocket;
+    if (destWebSocket.readyState === WebSocket.OPEN) {
+      switch(type) {
+        case 'message': destWebSocket.send(data, flags);
+        break;
+        case 'ping': destWebSocket.ping(data, flags, false);
+        break;
+        case 'pong': destWebSocket.pong(data, flags, false);
+        break;
       }
-      data = newData;
-      flags = newFlags;
-      return callback(null, data, flags);
-    });
-  }, function(err) {
-    if (err) {
-      return self._onWebSocketError(ctx, err);
-    }
-    if (ctx.clientToProxyWebSocket.readyState === WebSocket.OPEN) {
-      ctx.clientToProxyWebSocket.send(data, flags);
     } else {
-      self._onWebSocketError(ctx, new Error("Cannot receive message because clientToProxy WebSocket connection state is not OPEN"));
+      self._onWebSocketError(ctx, new Error('Cannot send ' + type + ' because ' + (fromServer ? 'clientToProxy' : 'proxyToServer') + ' WebSocket connection state is not OPEN'));
     }
   });
 };


### PR DESCRIPTION
- Add a `WebSocketFrame` event handler with `type` and `fromServer` discriminator parameters which also handles `message` frames
- internally bind `WebSocketMessage` and `WebSocketSend` handlers on the `WebSocketFrame` handler