### PR TITLE
Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ __Arguments__
   * port - The port to listen on (default: 8080).
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * silent - if set to true, nothing will be written to console (default: false)
+  * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
 
 __Example__
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -45,6 +45,7 @@ Proxy.prototype.listen = function(options) {
   this.options = options || {};
   this.silent = !!options.silent;
   this.httpPort = options.port || 8080;
+  this.timeout = options.timeout || 0;
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
   this.ca = new ca(this.sslCaDir);
   this.sslServers = {};
@@ -53,6 +54,7 @@ Proxy.prototype.listen = function(options) {
       self._onError("CERT_DIRECTORY_CREATION", null, err);
     }
     self.httpServer = http.createServer();
+    self.httpServer.timeout = this.timeout;
     self.httpServer.on('error', self._onError.bind(self, "HTTP_SERVER_ERROR", null));
     self.httpServer.on('connect', self._onHttpServerConnect.bind(self));
     self.httpServer.on('request', self._onHttpServerRequest.bind(self, false));
@@ -301,6 +303,7 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
           console.log('starting server for ' + hostname);
         }
         var httpsServer = https.createServer(results.httpsOptions);
+        httpsServer.timeout = self.timeout;
         httpsServer.on('error', self._onError.bind(self, "HTTPS_SERVER_ERROR", null));
         httpsServer.on('clientError', self._onError.bind(self, "HTTPS_CLIENT_ERROR", null));
         httpsServer.on('connect', self._onHttpServerConnect.bind(self));

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -54,7 +54,7 @@ Proxy.prototype.listen = function(options) {
       self._onError("CERT_DIRECTORY_CREATION", null, err);
     }
     self.httpServer = http.createServer();
-    self.httpServer.timeout = this.timeout;
+    self.httpServer.timeout = self.timeout;
     self.httpServer.on('error', self._onError.bind(self, "HTTP_SERVER_ERROR", null));
     self.httpServer.on('connect', self._onHttpServerConnect.bind(self));
     self.httpServer.on('request', self._onHttpServerRequest.bind(self, false));


### PR DESCRIPTION
- add timeout option to listen method
- use it to set internal [http & https servers
timeout](https://nodejs.org/api/http.html#http_server_timeout)
- set default to 0 (i.e. no timeout)

Fix #56 