### PR TITLE
replace agent: false by internal agent 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ __Arguments__
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * silent - if set to true, nothing will be written to console (default: false)
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
+  * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. Defaults to an internal Agent.
+  * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. Defaults to an internal Agent.
 
 __Example__
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -472,7 +472,7 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
   }
   ctx.proxyToServerWebSocketOptions = {
     url: url,
-    agent: ctx.isSSL ? httpsAgent : httpAgent,
+    agent: ctx.isSSL ? self.httpsAgent : self.httpAgent,
     headers: ptosHeaders
   };
   return self._onWebSocketConnection(ctx, function(err) {
@@ -579,7 +579,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     host: hostPort.host,
     port: hostPort.port,
     headers: ctx.clientToProxyRequest.headers,
-    agent: ctx.isSSL ? httpsAgent : httpAgent
+    agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
   };
   return self._onRequest(ctx, function(err) {
     if (err) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -45,6 +45,8 @@ Proxy.prototype.listen = function(options) {
   this.silent = !!options.silent;
   this.httpPort = options.port || 8080;
   this.timeout = options.timeout || 0;
+  this.httpAgent = options.httpAgent || new http.Agent();
+  this.httpsAgent = options.httpsAgent || new https.Agent();
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
   this.ca = new ca(this.sslCaDir);
   this.sslServers = {};
@@ -470,7 +472,7 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
   }
   ctx.proxyToServerWebSocketOptions = {
     url: url,
-    agent: false,
+    agent: ctx.isSSL ? httpsAgent : httpAgent,
     headers: ptosHeaders
   };
   return self._onWebSocketConnection(ctx, function(err) {
@@ -577,7 +579,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     host: hostPort.host,
     port: hostPort.port,
     headers: ctx.clientToProxyRequest.headers,
-    agent: false
+    agent: ctx.isSSL ? httpsAgent : httpAgent
   };
   return self._onRequest(ctx, function(err) {
     if (err) {


### PR DESCRIPTION
`agent: false` option had been set in order not to use the globalAgent which may be set to a proxy agent pointing to the currently running proxy.

But it also disable request pooling:
https://nodejs.org/api/http.html#http_http_request_options_callback

This PR fix this by setting agent to an internal agent (tweakable through options httpAgent and httpsAgent)

This allows a small boost of performance