### PR TITLE
add `forceSNI` option to listen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ __Arguments__
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
   * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. Defaults to an internal Agent.
   * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. Defaults to an internal Agent.
+  * forceSNI - force use of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by the client. Allow node-http-mitm-proxy to handle all HTTPS requests with a single internal server.
 
 __Example__
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ __Arguments__
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * silent - if set to true, nothing will be written to console (default: false)
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
-  * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. Defaults to an internal Agent.
-  * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. Defaults to an internal Agent.
+  * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. (default: internal Agent)
+  * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. (default: internal Agent)
   * forceSNI - force use of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by the client. Allow node-http-mitm-proxy to handle all HTTPS requests with a single internal server.
 
 __Example__

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -47,6 +47,10 @@ Proxy.prototype.listen = function(options) {
   this.timeout = options.timeout || 0;
   this.httpAgent = options.httpAgent || new http.Agent();
   this.httpsAgent = options.httpsAgent || new https.Agent();
+  this.forceSNI = !!options.forceSNI;
+  if (this.forceSNI && !this.silent) {
+    console.log('SNI enabled. Clients not supporting SNI may fail');
+  }
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
   this.ca = new ca(this.sslCaDir);
   this.sslServers = {};
@@ -243,7 +247,7 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
     if (sslServer) {
       return makeConnection(sslServer.port);
     } else {
-      return openHttpsServer(hostname, function(err, port) {
+      return getHttpsServer(hostname, function(err, port) {
         if (err) {
           return self._onError('OPEN_HTTPS_SERVER_ERROR', null, err);
         }
@@ -266,7 +270,7 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
     conn.on('error', self._onError.bind(self, 'PROXY_TO_PROXY_SOCKET_ERROR', null));
   }
 
-  function openHttpsServer(hostname, callback) {
+  function getHttpsServer(hostname, callback) {
     self.onCertificateRequired(hostname, function (err, files) {
       async.auto({
         'keyFileExists': function(callback) {
@@ -320,32 +324,75 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
         if (err) {
           return callback(err);
         }
-        if (!self.silent) {
-          console.log('starting server for ' + hostname);
-        }
-        var httpsServer = https.createServer(results.httpsOptions);
-        httpsServer.timeout = self.timeout;
-        httpsServer.on('error', self._onError.bind(self, 'HTTPS_SERVER_ERROR', null));
-        httpsServer.on('clientError', self._onError.bind(self, 'HTTPS_CLIENT_ERROR', null));
-        httpsServer.on('connect', self._onHttpServerConnect.bind(self));
-        httpsServer.on('request', self._onHttpServerRequest.bind(self, true));
-        self.wssServer = new WebSocket.Server({ server: httpsServer });
-        self.wssServer.on('connection', self._onWebSocketServerConnect.bind(self, true));
-        httpsServer.listen(function() {
-          results.openPort = httpsServer.address().port;
-          if (!self.silent) {
-            console.log('server started for %s on port %d', hostname, results.openPort);
+        if (self.forceSNI) {
+          if (self.httpsServer) {
+            results.openPort = self.httpsPort;
+            if (!self.silent) {
+              console.log('creating SNI context for ' + hostname);
+            }
+        	self.httpsServer.addContext(hostname, results.httpsOptions);
+        	self.sslServers[hostname] = {
+              port: results.openPort
+            };
+            return callback(null, results.openPort);
+          } else {
+        	if (!self.silent) {
+              console.log('starting HTTPS server');
+            }
+        	self.httpsServer = createHttpsServer({}, function(httpsServer, wssServer) {
+          	  results.openPort = httpsServer.address().port;
+              if (!self.silent) {
+                console.log('HTTPS server started on port %d', results.openPort);
+              }
+        	  self.httpsServer = httpsServer;
+        	  self.wssServer = wssServer;
+        	  self.httpsPort = results.openPort;
+        	  if (!self.silent) {
+                console.log('creating SNI context for ' + hostname);
+              }
+        	  self.httpsServer.addContext(hostname, results.httpsOptions);
+          	  self.sslServers[hostname] = {
+                port: results.openPort
+              };
+        	  return callback(null, results.openPort);
+        	});
           }
-          self.sslServers[hostname] = {
-            port: results.openPort,
-            server: httpsServer
-          };
-          callback(null, results.openPort);
-        });
+        } else {
+          if (!self.silent) {
+            console.log('starting server for ' + hostname);
+          }
+          createHttpsServer(results.httpsOptions, function(httpsServer, wssServer) {
+        	results.openPort = httpsServer.address().port;
+            if (!self.silent) {
+              console.log('server started for %s on port %d', hostname, results.openPort);
+            }
+            self.sslServers[hostname] = {
+              port: results.openPort,
+              server: httpsServer,
+              wsServer: wssServer
+            };
+            return callback(null, results.openPort);
+          });
+        }
       });
     });
   }
+    
+  function createHttpsServer(options, callback) {
+    var httpsServer = https.createServer(options);
+    httpsServer.timeout = self.timeout;
+    httpsServer.on('error', self._onError.bind(self, 'HTTPS_SERVER_ERROR', null));
+    httpsServer.on('clientError', self._onError.bind(self, 'HTTPS_CLIENT_ERROR', null));
+    httpsServer.on('connect', self._onHttpServerConnect.bind(self));
+    httpsServer.on('request', self._onHttpServerRequest.bind(self, true));
+    var wssServer = new WebSocket.Server({ server: httpsServer });
+    wssServer.on('connection', self._onWebSocketServerConnect.bind(self, true));
+    httpsServer.listen(function() {
+      callback(httpsServer, wssServer);
+    });
+  }
 };
+
 
 Proxy.prototype.onCertificateRequired = function (hostname, callback) {
   var self = this;


### PR DESCRIPTION
When enabled, it allows to handle all HTTPS requests with a single
internal server which free ports and give a small performance boost.

The downside is that the proxy would probably not work with clients that
don't supports SNI (obsolete clients https://en.wikipedia.org/wiki/Server_Name_Indication)