### PR TITLE
Filter HPKP Headers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -690,7 +690,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
         if (err) {
           return self._onError('ON_RESPONSEHEADERS_ERROR', ctx, err);
         }
-        ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, canonizeHeaders(ctx.serverToProxyResponse.headers));
+        ctx.proxyToClientResponse.writeHead(ctx.serverToProxyResponse.statusCode, Proxy.filterAndCanonizeHeaders(ctx.serverToProxyResponse.headers));
         ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
         var prevResponsePipeElem = ctx.serverToProxyResponse;
         ctx.responseFilters.forEach(function(filter) {
@@ -701,15 +701,6 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     });
   }
 };
-
-var canonizeHeaders = function(originalHeaders) {
-  var headers = {};
-  for (var key in originalHeaders) {
-    headers[key.trim()] = originalHeaders[key];
-  }
-
-  return headers;
-}
 
 var ProxyFinalRequestFilter = function(proxy, ctx) {
   events.EventEmitter.call(this);
@@ -994,4 +985,17 @@ Proxy.parseHost = function(hostString, defaultPort) {
     host: host,
     port: port
   };
+};
+
+Proxy.filterAndCanonizeHeaders = function(originalHeaders) {
+  var headers = {};
+  for (var key in originalHeaders) {
+	var canonizedKey = key.trim();
+    if ('/^public\-key\-pins/i'.test(canonizedKey)) {
+      // KPKP header => filter
+      continue;
+    }
+    headers[canonizedKey] = originalHeaders[key];
+  }
+  return headers;
 };


### PR DESCRIPTION
[HPKP](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) is an Http Extension used to prevent usage of MITM Proxy.
The server add headers to http response with a hash to compare used certificates among.
As a result, clients supporting HPKP may fail and/or report errors with MITM proxy, even when the fake CA is installed locally.

The PR filter thoose headers.

It allow to prevent errors and report when the mitm proxy is installed permanently.
Due to HPKP cache, there may still be errors when the client have browsed without the proxy enabled before (or using previous versions of the proxy)