### PR TITLE
Unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,15 @@ Starts the proxy listening on the given port.
 __Arguments__
 
  * options - An object with the following options:
-  * port - The port to listen on (default: 8080).
+  * port - The port or named socket to listen on (default: 8080).
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * silent - if set to true, nothing will be written to console (default: false)
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
   * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. (default: internal Agent)
   * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. (default: internal Agent)
   * forceSNI - force use of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by the client. Allow node-http-mitm-proxy to handle all HTTPS requests with a single internal server.
+  * httpsPort - The port or named socket for https server to listen on. _(forceSNI must be enabled)_
+  * useNamedSocket - use named socket (i.e. unix socket or named pipe) instead of TCP ports for internal server(s)
 
 __Example__
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -11,6 +11,7 @@ var events = require('events');
 var mkdirps = require('mkdirps');
 var WebSocket = require('ws');
 var url = require('url');
+var os = require('os');
 var semaphore = require('semaphore');
 var ca = require('./ca.js');
 
@@ -53,6 +54,8 @@ Proxy.prototype.listen = function(options, callback) {
   if (this.forceSNI && !this.silent) {
     console.log('SNI enabled. Clients not supporting SNI may fail');
   }
+  this.useNamedSocket = !!options.useNamedSocket;
+  this.httpsPort = this.forceSNI ? options.httpsPort : undefined;
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
   this.ca = new ca(this.sslCaDir);
   this.sslServers = {};
@@ -70,10 +73,13 @@ Proxy.prototype.listen = function(options, callback) {
     self.wsServer.on('connection', self._onWebSocketServerConnect.bind(self, false));
     if (self.forceSNI) {
       // start the single HTTPS server now
-      self._createHttpsServer({}, function(httpsServer, wssServer) {
+      self._createHttpsServer({}, function(portOrSocket, httpsServer, wssServer) {
+        if (!self.silent) {
+          console.log('https server started on '+portOrSocket);
+        }
         self.httpsServer = httpsServer;
         self.wssServer = wssServer;
-        self.httpsPort = httpsServer.address().port;
+        self.httpsPort = portOrSocket;
         self.httpServer.listen(self.httpPort, callback);
       });
     } else {
@@ -93,8 +99,9 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   httpsServer.on('request', this._onHttpServerRequest.bind(this, true));
   var wssServer = new WebSocket.Server({ server: httpsServer });
   wssServer.on('connection', this._onWebSocketServerConnect.bind(this, true));
-  httpsServer.listen(function() {
-    if (callback) callback(httpsServer, wssServer);
+  var portOrSocket = this.httpsPort || (this.useNamedSocket ? Proxy.newNamedSocket() : undefined);
+  httpsServer.listen(portOrSocket, function() {
+    if (callback) callback(portOrSocket || httpsServer.address().port, httpsServer, wssServer);
   });
 };
 
@@ -312,9 +319,9 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
     return makeConnection(this.httpPort);
   }
 
-  function makeConnection(port) {
+  function makeConnection(portOrSocket) {
     // open a TCP connection to the remote host
-    var conn = net.connect(port, 'localhost', function() {
+    var conn = net.connect(portOrSocket, function() {
       // create a tunnel between the two hosts
       socket.pipe(conn);
       conn.pipe(socket);
@@ -403,20 +410,19 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
           if (!self.silent) {
             console.log('starting server for ' + hostname);
           }
-          self._createHttpsServer(results.httpsOptions, function(httpsServer, wssServer) {
-            var openPort = httpsServer.address().port;
+          self._createHttpsServer(results.httpsOptions, function(portOrSocket, httpsServer, wssServer) {
             if (!self.silent) {
-              console.log('server started for %s on port %d', hostname, openPort);
+              console.log('https server started for %s on %s', hostname, portOrSocket);
             }
             var sslServer = {
               server: httpsServer,
               wsServer: wssServer,
-              port: openPort
+              port: portOrSocket
             };
             hosts.forEach(function(host) {
               self.sslServers[hostname] = sslServer;
             });
-            return callback(null, openPort);
+            return callback(null, portOrSocket);
           });
         }
       });
@@ -1009,4 +1015,15 @@ Proxy.filterAndCanonizeHeaders = function(originalHeaders) {
     headers[canonizedKey] = originalHeaders[key];
   }
   return headers;
+};
+
+Proxy.NAMED_SOCKET_PREFIX = 'mitm-proxy-' + Math.random().toString(36).substring(2, 10);
+Proxy.NAMED_SOCKET_INDEX = 0;
+Proxy.newNamedSocket = function() {
+  var socketName = Proxy.NAMED_SOCKET_PREFIX + "-" + Proxy.NAMED_SOCKET_INDEX++;
+  if (/^win/.test(process.platform)) {
+    return '\\\\.\\pipe\\' + socketName + '-sock';
+  } else {
+    return path.join(os.tmpdir(), socketName+".sock")
+  }
 };


### PR DESCRIPTION
add httpsPort and useNamedSocket options:
- httpsPort: tweak internally used port in case of single https server (forceSNI must be enabled).
- useNamedSocket: use named socket (i.e. unix socket or named pipe) instead of TCP ports for internal server(s). It should makes it faster. Works well on unix. I got strange troubles on windows. That why I disabled it by default