### PR TITLE
Transfer-encoding and Connection:close headers ???

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -701,8 +701,6 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       if (err) {
         return self._onError('ON_RESPONSE_ERROR', ctx, err);
       }
-      ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
-      ctx.serverToProxyResponse.headers['connection'] = 'close';
       return self._onResponseHeaders(ctx, function (err) {
         if (err) {
           return self._onError('ON_RESPONSEHEADERS_ERROR', ctx, err);


### PR DESCRIPTION
When using nodejs 5.6+ to make a request through the proxy, I get the following error:
```
Parse Error (HPE_UNEXPECTED_CONTENT_LENGTH)
```

According to [this post](http://stackoverflow.com/questions/35525715/http-get-parse-error-code-hpe-unexpected-content-length), this is due to `Content-Length` and `Transfer-encoding: chunked` headers being set together, which seems illegal according to HTTP spec.

Removing the forced set of `transfer-encoding` header fix the issue.
I also tried to remove the `connection: close` header and it does not seems to have any effect.

__Before merging this__
I there any good reason for forcing thoose headers?
