### PR TITLE
Keep alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ __Arguments__
   * port - The port or named socket to listen on (default: 8080).
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * silent - if set to true, nothing will be written to console (default: false)
+  * keepAlive - enable [HTTP persistent connection](https://en.wikipedia.org/wiki/HTTP_persistent_connection)
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.
   * httpAgent - The [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) to use when making http requests. Useful for chaining proxys. (default: internal Agent)
   * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. (default: internal Agent)

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -49,8 +49,8 @@ Proxy.prototype.listen = function(options, callback) {
   this.httpPort = options.port || 8080;
   this.timeout = options.timeout || 0;
   this.keepAlive = !!options.keepAlive;
-  this.httpAgent = options.httpAgent || new http.Agent({ keepAlive: this.keepAlive });
-  this.httpsAgent = options.httpsAgent || new https.Agent({ keepAlive: this.keepAlive });
+  this.httpAgent = typeof(options.httpAgent) !== "undefined" ? options.httpAgent : new http.Agent({ keepAlive: this.keepAlive });
+  this.httpsAgent = typeof(options.httpsAgent) !== "undefined" ? options.httpsAgent : new https.Agent({ keepAlive: this.keepAlive });
   this.forceSNI = !!options.forceSNI;
   if (this.forceSNI && !this.silent) {
     console.log('SNI enabled. Clients not supporting SNI may fail');

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,8 +48,8 @@ Proxy.prototype.listen = function(options, callback) {
   this.silent = !!options.silent;
   this.httpPort = options.port || 8080;
   this.timeout = options.timeout || 0;
-  this.httpAgent = options.httpAgent || new http.Agent();
-  this.httpsAgent = options.httpsAgent || new https.Agent();
+  this.httpAgent = options.httpAgent || new http.Agent({ keepAlive: true });
+  this.httpsAgent = options.httpsAgent || new https.Agent({ keepAlive: true });
   this.forceSNI = !!options.forceSNI;
   if (this.forceSNI && !this.silent) {
     console.log('SNI enabled. Clients not supporting SNI may fail');
@@ -703,7 +703,10 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       }
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       delete ctx.serverToProxyResponse.headers['content-length'];
-      ctx.serverToProxyResponse.headers['connection'] = 'close';
+      if (!ctx.serverToProxyResponse.headers['connection']) {
+    	var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
+        ctx.serverToProxyResponse.headers['connection'] = keepAlive ? 'keep-alive' : 'close';
+      }
       return self._onResponseHeaders(ctx, function (err) {
         if (err) {
           return self._onError('ON_RESPONSEHEADERS_ERROR', ctx, err);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,8 +48,9 @@ Proxy.prototype.listen = function(options, callback) {
   this.silent = !!options.silent;
   this.httpPort = options.port || 8080;
   this.timeout = options.timeout || 0;
-  this.httpAgent = options.httpAgent || new http.Agent({ keepAlive: true });
-  this.httpsAgent = options.httpsAgent || new https.Agent({ keepAlive: true });
+  this.keepAlive = !!options.keepAlive;
+  this.httpAgent = options.httpAgent || new http.Agent({ keepAlive: this.keepAlive });
+  this.httpsAgent = options.httpsAgent || new https.Agent({ keepAlive: this.keepAlive });
   this.forceSNI = !!options.forceSNI;
   if (this.forceSNI && !this.silent) {
     console.log('SNI enabled. Clients not supporting SNI may fail');
@@ -703,9 +704,13 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       }
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       delete ctx.serverToProxyResponse.headers['content-length'];
-      if (!ctx.serverToProxyResponse.headers['connection']) {
-        var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
-        ctx.serverToProxyResponse.headers['connection'] = keepAlive ? 'keep-alive' : 'close';
+      if (self.keepAlive) {
+        if (!ctx.serverToProxyResponse.headers['connection']) {
+          var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
+          ctx.serverToProxyResponse.headers['connection'] = keepAlive ? 'keep-alive' : 'close';
+        }
+      } else {
+        ctx.serverToProxyResponse.headers['connection'] = 'close';
       }
       return self._onResponseHeaders(ctx, function (err) {
         if (err) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -704,7 +704,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       delete ctx.serverToProxyResponse.headers['content-length'];
       if (!ctx.serverToProxyResponse.headers['connection']) {
-    	var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
+        var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
         ctx.serverToProxyResponse.headers['connection'] = keepAlive ? 'keep-alive' : 'close';
       }
       return self._onResponseHeaders(ctx, function (err) {


### PR DESCRIPTION
Support of keepAlive.
Sockets between client and proxy and between proxy and server are kept alive for a while and reused for successives requests (when supported by server and client).
Timeout an max open socket limits are default ones. 

I made a few tests without any issue. It seems to really boost the perfs.