### PR TITLE
Remove useNamedSocket option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ __Arguments__
   * httpsAgent - The [https.Agent](https://nodejs.org/api/https.html#https_class_https_agent) to use when making https requests. Useful for chaining proxys. (default: internal Agent)
   * forceSNI - force use of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by the client. Allow node-http-mitm-proxy to handle all HTTPS requests with a single internal server.
   * httpsPort - The port or named socket for https server to listen on. _(forceSNI must be enabled)_
-  * useNamedSocket - use named socket (i.e. unix socket or named pipe) instead of TCP ports for internal server(s)
 
 __Example__
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -54,7 +54,6 @@ Proxy.prototype.listen = function(options, callback) {
   if (this.forceSNI && !this.silent) {
     console.log('SNI enabled. Clients not supporting SNI may fail');
   }
-  this.useNamedSocket = !!options.useNamedSocket;
   this.httpsPort = this.forceSNI ? options.httpsPort : undefined;
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
   ca.create(this.sslCaDir, function(err, ca) {
@@ -73,13 +72,13 @@ Proxy.prototype.listen = function(options, callback) {
     self.wsServer.on('connection', self._onWebSocketServerConnect.bind(self, false));
     if (self.forceSNI) {
       // start the single HTTPS server now
-      self._createHttpsServer({}, function(portOrSocket, httpsServer, wssServer) {
+      self._createHttpsServer({}, function(port, httpsServer, wssServer) {
         if (!self.silent) {
-          console.log('https server started on '+portOrSocket);
+          console.log('https server started on '+port);
         }
         self.httpsServer = httpsServer;
         self.wssServer = wssServer;
-        self.httpsPort = portOrSocket;
+        self.httpsPort = port;
         self.httpServer.listen(self.httpPort, callback);
       });
     } else {
@@ -99,9 +98,8 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   httpsServer.on('request', this._onHttpServerRequest.bind(this, true));
   var wssServer = new WebSocket.Server({ server: httpsServer });
   wssServer.on('connection', this._onWebSocketServerConnect.bind(this, true));
-  var portOrSocket = this.httpsPort || (this.useNamedSocket ? Proxy.newNamedSocket() : undefined);
-  httpsServer.listen(portOrSocket, function() {
-    if (callback) callback(portOrSocket || httpsServer.address().port, httpsServer, wssServer);
+  httpsServer.listen(this.httpsPort || undefined, function() {
+    if (callback) callback(httpsServer.address().port, httpsServer, wssServer);
   });
 };
 
@@ -319,9 +317,9 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
     return makeConnection(this.httpPort);
   }
 
-  function makeConnection(portOrSocket) {
+  function makeConnection(port) {
     // open a TCP connection to the remote host
-    var conn = net.connect(portOrSocket, function() {
+    var conn = net.connect(port, function() {
       // create a tunnel between the two hosts
       socket.pipe(conn);
       conn.pipe(socket);
@@ -410,19 +408,19 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
           if (!self.silent) {
             console.log('starting server for ' + hostname);
           }
-          self._createHttpsServer(results.httpsOptions, function(portOrSocket, httpsServer, wssServer) {
+          self._createHttpsServer(results.httpsOptions, function(port, httpsServer, wssServer) {
             if (!self.silent) {
-              console.log('https server started for %s on %s', hostname, portOrSocket);
+              console.log('https server started for %s on %s', hostname, port);
             }
             var sslServer = {
               server: httpsServer,
               wsServer: wssServer,
-              port: portOrSocket
+              port: port
             };
             hosts.forEach(function(host) {
               self.sslServers[hostname] = sslServer;
             });
-            return callback(null, portOrSocket);
+            return callback(null, port);
           });
         }
       });
@@ -1023,15 +1021,4 @@ Proxy.filterAndCanonizeHeaders = function(originalHeaders) {
     headers[canonizedKey] = originalHeaders[key];
   }
   return headers;
-};
-
-Proxy.NAMED_SOCKET_PREFIX = 'mitm-proxy-' + Math.random().toString(36).substring(2, 10);
-Proxy.NAMED_SOCKET_INDEX = 0;
-Proxy.newNamedSocket = function() {
-  var socketName = Proxy.NAMED_SOCKET_PREFIX + "-" + Proxy.NAMED_SOCKET_INDEX++;
-  if (/^win/.test(process.platform)) {
-    return '\\\\.\\pipe\\' + socketName + '-sock';
-  } else {
-    return path.join(os.tmpdir(), socketName+".sock")
-  }
 };


### PR DESCRIPTION
useNamedSocket option is not working properly.
- On windows + nodejs 5.6 it crash nodejs
- On unix it works on most requests but fail on others (ex: all images
on twitter), when creating the internal socket connection.

Both may be due to concurrent connection over the same named pipe but I
don't have enough information to be sure.

This experiment is not yet working and should be removed from master