### PR TITLE
Various keepAlive fixes & improvements

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -274,7 +274,7 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
 
   /*
   * Detect TLS from first bytes of data
-  * Inspered from https://gist.github.com/tg-x/835636
+  * Inspired from https://gist.github.com/tg-x/835636
   * used heuristic:
   * - an incoming connection using SSLv3/TLSv1 records should start with 0x16
   * - an incoming connection using SSLv2 records should start with the record size

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -263,11 +263,12 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
   
   // we need first byte of data to detect if request is SSL encrypted
   if (!head || head.length === 0) {
-    socket.once('data', function(data) {
-      self._onHttpServerConnect(req, socket, data);
-    });
-    // respond to the client that the connection was made so it can send us data
-    return socket.write('HTTP/1.1 200 OK\r\n\r\n');
+    socket.once('data', self._onHttpServerConnect.bind(self, req, socket));
+    socket.write('HTTP/1.1 200 OK\r\n');
+    if (self.keepAlive && req.headers['proxy-connection'] === 'keep-alive') {
+      socket.write('Proxy-Connection: Keep-Alive\r\n');
+    }
+    return socket.write('\r\n');
   }
 
   socket.pause();
@@ -709,9 +710,8 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
       delete ctx.serverToProxyResponse.headers['content-length'];
       if (self.keepAlive) {
-        if (!ctx.serverToProxyResponse.headers['connection']) {
-          var keepAlive = ctx.clientToProxyRequest.headers && ctx.clientToProxyRequest.headers['connection'] && ctx.clientToProxyRequest.headers['connection'].trim().toLowerCase() === 'keep-alive';
-          ctx.serverToProxyResponse.headers['connection'] = keepAlive ? 'keep-alive' : 'close';
+        if (ctx.clientToProxyRequest.headers['proxy-connection']) {
+          ctx.serverToProxyResponse.headers['proxy-connection'] = 'keep-alive';
         }
       } else {
         ctx.serverToProxyResponse.headers['connection'] = 'close';

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -659,12 +659,19 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   ctx.proxyToClientResponse.on('error', self._onError.bind(self, 'PROXY_TO_CLIENT_RESPONSE_ERROR', ctx));
   ctx.clientToProxyRequest.pause();
   var hostPort = Proxy.parseHostAndPort(ctx.clientToProxyRequest, ctx.isSSL ? 443 : 80);
+  var headers = {};
+  for (var h in ctx.clientToProxyRequest.headers) {
+    // don't forward proxy- headers
+    if (/^proxy\-/i.test(h)) {
+      headers[h] = ctx.clientToProxyRequest.headers[h];
+    }
+  }
   ctx.proxyToServerRequestOptions = {
     method: ctx.clientToProxyRequest.method,
     path: ctx.clientToProxyRequest.url,
     host: hostPort.host,
     port: hostPort.port,
-    headers: ctx.clientToProxyRequest.headers,
+    headers: headers,
     agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
   };
   return self._onRequest(ctx, function(err) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -266,7 +266,8 @@ Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
     socket.once('data', self._onHttpServerConnect.bind(self, req, socket));
     socket.write('HTTP/1.1 200 OK\r\n');
     if (self.keepAlive && req.headers['proxy-connection'] === 'keep-alive') {
-      socket.write('Proxy-Connection: Keep-Alive\r\n');
+      socket.write('Proxy-Connection: keep-alive\r\n');
+      socket.write('Connection: keep-alive\r\n');
     }
     return socket.write('\r\n');
   }
@@ -712,6 +713,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       if (self.keepAlive) {
         if (ctx.clientToProxyRequest.headers['proxy-connection']) {
           ctx.serverToProxyResponse.headers['proxy-connection'] = 'keep-alive';
+          ctx.serverToProxyResponse.headers['connection'] = 'keep-alive';
         }
       } else {
         ctx.serverToProxyResponse.headers['connection'] = 'close';


### PR DESCRIPTION
- Don't forward proxy-* headers to server (most clients add headers for the proxy that should not be transfered to the server)
- In keepAlive mode, handles `proxy-connection: keep-alive` header
- In keepAlive connection, don't force connection header (leave it untouched even when it does not exists)