### PR TITLE
support automatic cert creation for IP addresses

### DIFF
--- a/lib/ca.js
+++ b/lib/ca.js
@@ -213,6 +213,9 @@ CA.prototype.generateServerCertificateKeys = function (hosts, cb) {
   certServer.setExtensions(ServerExtensions.concat([{
     name: 'subjectAltName',
     altNames: hosts.map(function(host) {
+      if (host.match(/^[\d\.]+$/)) {
+        return {type: 7, ip: host};
+      }
       return {type: 2, value: host};
     })
   }]));


### PR DESCRIPTION
Hello! I ran into some issues trying to use node-http-mitm-proxy with IP addresses. It works great except that the generated cert has an invalid subject alternative name.

This [node-forge example](https://github.com/digitalbazaar/forge/blob/master/README.md#x509) shows how the subject alt name should be specified for an IP address. I've followed that example.

Please let me know if there is anything that I can do to improve this PR or my commit and I'd be happy to do so. Thanks! :)
