### PR TITLE
handle response and request filters errors

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -695,6 +695,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     ctx.requestFilters.push(new ProxyFinalRequestFilter(self, ctx));
     var prevRequestPipeElem = ctx.clientToProxyRequest;
     ctx.requestFilters.forEach(function(filter) {
+      filter.on('error', self._onError.bind(self, 'REQUEST_FILTER_ERROR', ctx));
       prevRequestPipeElem = prevRequestPipeElem.pipe(filter);
     });
     ctx.clientToProxyRequest.resume();
@@ -726,6 +727,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
         ctx.responseFilters.push(new ProxyFinalResponseFilter(self, ctx));
         var prevResponsePipeElem = ctx.serverToProxyResponse;
         ctx.responseFilters.forEach(function(filter) {
+          filter.on('error', self._onError.bind(self, 'RESPONSE_FILTER_ERROR', ctx));
           prevResponsePipeElem = prevResponsePipeElem.pipe(filter);
         });
         return ctx.serverToProxyResponse.resume();


### PR DESCRIPTION
This forward the request and response filters errors to onError handler.
It allows to catch gunzip module errors for example.