### PR TITLE
set accept-encoding header to gzip when using gunzip middleware

### DIFF
--- a/lib/middleware/gunzip.js
+++ b/lib/middleware/gunzip.js
@@ -10,6 +10,10 @@ module.exports = {
       ctx.addResponseFilter(zlib.createGunzip());
     }
     return callback();
+  },
+  onRequest: function(ctx, callback) {
+    ctx.proxyToServerRequestOptions.headers['accept-encoding'] = 'gzip';
+    return callback();
   }
 };
 


### PR DESCRIPTION
Otherwise the server may use another content-encoding algorythm (like SDCH for example)

Fix #80