### PR TITLE
Removing Content-Length from clientToProxyRequest

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -700,6 +700,8 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       headers[h] = ctx.clientToProxyRequest.headers[h];
     }
   }
+  delete headers['content-length'];
+
   ctx.proxyToServerRequestOptions = {
     method: ctx.clientToProxyRequest.method,
     path: ctx.clientToProxyRequest.url,


### PR DESCRIPTION
Hey and thanks for this great project, which supports the core of my [pokemon-go-mitm-node](https://github.com/rastapasta/pokemon-go-mitm-node) project.

Just ran into one issue:
When tampering request bodys of requests sent from the client to the proxy, the content-length was kept in the headers - in the response handling they got taken out already.

By removing it from the client request, the encoding will be set automatically to chunked -> no content-length needed -> #win and injectability :) 

Cheers!