### PR TITLE
Fix websocket error: not opened

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -612,7 +612,9 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
     ctx.proxyToServerWebSocket.on('error', self._onWebSocketError.bind(self, ctx));
     ctx.proxyToServerWebSocket.on('close', self._onWebSocketClose.bind(self, ctx, true));
     ctx.proxyToServerWebSocket.on('open', function() {
+      if (ctx.clientToProxyWebSocket.readyState === WebSocket.OPEN) {
         ctx.clientToProxyWebSocket.resume();
+      }
     });
   }
 }


### PR DESCRIPTION
Surfing e.g. on github I get this error a lot:

```
/home/vagrant/projects/grape/grape-web-client/node_modules/ws/lib/WebSocket.js:197
  if (this.readyState !== WebSocket.OPEN) throw new Error('not opened');
                                          ^

Error: not opened
    at WebSocket.resume (/home/vagrant/projects/grape/grape-web-client/node_modules/ws/lib/WebSocket.js:197:49)
    at WebSocket.<anonymous> (/home/vagrant/projects/grape/grape-web-client/node_modules/http-mitm-proxy/lib/proxy.js:613:36)
    at emitNone (events.js:86:13)
    at WebSocket.emit (events.js:185:7)
    at WebSocket.establishConnection (/home/vagrant/projects/grape/grape-web-client/node_modules/ws/lib/WebSocket.js:887:8)
    at ClientRequest.upgrade (/home/vagrant/projects/grape/grape-web-client/node_modules/ws/lib/WebSocket.js:778:25)
    at ClientRequest.g (events.js:286:16)
    at emitThree (events.js:116:13)
    at ClientRequest.emit (events.js:194:7)
    at TLSSocket.socketOnData (_http_client.js:393:11)
```

which crashes the whole web proxy.
Adding this check seems to fix the issue.