### PR TITLE
Updating onResponseEnd example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ __Arguments__
 __Example__
 
     proxy.onResponseEnd(function(ctx, callback) {
-      console.log('RESPONSE END', chunk.toString());
+      console.log('RESPONSE END');
       return callback();
     });
 


### PR DESCRIPTION
onResponseEnd callback doesn't receive the parameter chunk so it doesn't make sense to reference it in the example.