### PR TITLE
Avoid uncaught exception on http server error

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -67,10 +67,10 @@ Proxy.prototype.listen = function(options, callback) {
     self.sslSemaphores = {};
     self.httpServer = http.createServer();
     self.httpServer.timeout = self.timeout;
-    self.httpServer.on('error', self._onError.bind(self, 'HTTP_SERVER_ERROR', null));
     self.httpServer.on('connect', self._onHttpServerConnect.bind(self));
     self.httpServer.on('request', self._onHttpServerRequest.bind(self, false));
     self.wsServer = new WebSocket.Server({ server: self.httpServer });
+    self.wsServer.on('error', self._onError.bind(self, 'HTTP_SERVER_ERROR', null));
     self.wsServer.on('connection', self._onWebSocketServerConnect.bind(self, false));
     const listenOptions = {
       host: self.httpHost,


### PR DESCRIPTION
Fixes #131 (option 1)

Listen to the websocket server error event (which in turn listens to the http server error event) and not the http server error event directly.