### PR TITLE
Fix compatibility with updated ws dependency

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -506,7 +506,7 @@ Proxy.prototype._onError = function(kind, ctx, err) {
   }
 };
 
-Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
+Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws, upgradeReq) {
   var self = this;
   var ctx = {
     isSSL: isSSL,
@@ -580,14 +580,14 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws) {
   ctx.clientToProxyWebSocket.on('close', self._onWebSocketClose.bind(self, ctx, false));
   ctx.clientToProxyWebSocket.pause();
   var url;
-  if (ctx.clientToProxyWebSocket.upgradeReq.url == '' || /^\//.test(ctx.clientToProxyWebSocket.upgradeReq.url)) {
-    var hostPort = Proxy.parseHostAndPort(ctx.clientToProxyWebSocket.upgradeReq);
-    url = (ctx.isSSL ? 'wss' : 'ws') + '://' + hostPort.host + (hostPort.port ? ':' + hostPort.port : '') + ctx.clientToProxyWebSocket.upgradeReq.url;
+  if (upgradeReq.url == '' || /^\//.test(upgradeReq.url)) {
+    var hostPort = Proxy.parseHostAndPort(upgradeReq);
+    url = (ctx.isSSL ? 'wss' : 'ws') + '://' + hostPort.host + (hostPort.port ? ':' + hostPort.port : '') + upgradeReq.url;
   } else {
-    url = ctx.clientToProxyWebSocket.upgradeReq.url;
+    url = upgradeReq.url;
   }
   var ptosHeaders = {};
-  var ctopHeaders = ctx.clientToProxyWebSocket.upgradeReq.headers;
+  var ctopHeaders = upgradeReq.headers;
   for (var key in ctopHeaders) {
     if (key.indexOf('sec-websocket') !== 0) {
       ptosHeaders[key] = ctopHeaders[key];


### PR DESCRIPTION
The `ws` API changed such that `upgradeReq` is no longer a property of the web socket object. The request is instead passed as an additional parameter to the connect event handler.

Fixes #140 