### PR TITLE
Add binding IP for httpsServer as well. 

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -104,9 +104,18 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   var listenArgs = [function() {
     if (callback) callback(httpsServer.address().port, httpsServer, wssServer);
   }];
+  // Using listenOptions to bind the server to a particular IP if requested via options.host
+  // port 0 to get the first available port
+  var listenOptions = {
+    port: 0
+  };
   if (this.httpsPort && !options.hosts) {
-    listenArgs.unshift(this.httpsPort);
+    listenOptions.port = this.httpsPort;
   }
+  if (this.httpHost)
+    listenOptions.host = this.httpHost;
+  listenArgs.unshift(listenOptions);
+  
   httpsServer.listen.apply(httpsServer, listenArgs);
 };
 


### PR DESCRIPTION
Fix to https://github.com/joeferner/node-http-mitm-proxy/issues/146