### PR TITLE
fix upgradeReq is undefined

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -68,7 +68,10 @@ Proxy.prototype.listen = function(options, callback) {
     self.httpServer.on('request', self._onHttpServerRequest.bind(self, false));
     self.wsServer = new WebSocket.Server({ server: self.httpServer });
     self.wsServer.on('error', self._onError.bind(self, 'HTTP_SERVER_ERROR', null));
-    self.wsServer.on('connection', self._onWebSocketServerConnect.bind(self, false));
+    self.wsServer.on('connection', function(ws, req){
+		  ws.upgradeReq = req;
+		  self._onWebSocketServerConnect.bind(self, false);
+	  });
     const listenOptions = {
       host: self.httpHost,
       port: self.httpPort
@@ -100,7 +103,10 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   httpsServer.on('connect', this._onHttpServerConnect.bind(this));
   httpsServer.on('request', this._onHttpServerRequest.bind(this, true));
   var wssServer = new WebSocket.Server({ server: httpsServer });
-  wssServer.on('connection', this._onWebSocketServerConnect.bind(this, true));
+  wssServer.on('connection', function(ws, req){
+		ws.upgradeReq = req;
+		this._onWebSocketServerConnect.bind(this, true)
+	});
   var listenArgs = [function() {
     if (callback) callback(httpsServer.address().port, httpsServer, wssServer);
   }];


### PR DESCRIPTION
an optimization in version 3.0 of the required proxy server [ https://github.com/websockets/ws/issues/1114 ]drops the upgradeReq parameter to save 20% in memory.  This breaks non-http(s) requests that use upgrade to switch - like web sockets (ws and wss).  This was never a consideration for he mitm proxy (I guess since the package specifies version 3.2 and up - so it never worked).  This matters for me so we re include it per the recommendation from the package maintainers [ https://github.com/websockets/ws/pull/1099 ]