### PR TITLE
Fix WebSocket Proxying

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -70,7 +70,7 @@ Proxy.prototype.listen = function(options, callback) {
     self.wsServer.on('error', self._onError.bind(self, 'HTTP_SERVER_ERROR', null));
     self.wsServer.on('connection', (ws, req) => {
 		  ws.upgradeReq = req;
-		  self._onWebSocketServerConnect.bind(self, false);
+		  self._onWebSocketServerConnect.call(self, false, ws, req);
 	  });
     const listenOptions = {
       host: self.httpHost,
@@ -102,10 +102,11 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   httpsServer.on('clientError', this._onError.bind(this, 'HTTPS_CLIENT_ERROR', null));
   httpsServer.on('connect', this._onHttpServerConnect.bind(this));
   httpsServer.on('request', this._onHttpServerRequest.bind(this, true));
+  var self = this;
   var wssServer = new WebSocket.Server({ server: httpsServer });
   wssServer.on('connection', function(ws, req){
 		ws.upgradeReq = req;
-		this._onWebSocketServerConnect.bind(this, true)
+		self._onWebSocketServerConnect.call(self, true, ws, req)
 	});
   var listenArgs = [function() {
     if (callback) callback(httpsServer.address().port, httpsServer, wssServer);
@@ -121,7 +122,7 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   if (this.httpHost)
     listenOptions.host = this.httpHost;
   listenArgs.unshift(listenOptions);
-  
+
   httpsServer.listen.apply(httpsServer, listenArgs);
 };
 

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -1,4 +1,3 @@
-
 var util = require('util');
 var assert = require('assert');
 var crypto = require('crypto');
@@ -70,24 +69,24 @@ describe('proxy', function () {
     });
     srvB.listen(testPortB, testHost);
   });
-  
+
   beforeEach(function (done) {
     proxy = new Proxy();
     proxy.listen({ port: testProxyPort, silent: true }, done);
   });
-  
+
   afterEach(function () {
     proxy.close();
     proxy = null;
   });
-  
+
   after(function () {
     srvA.close();
     srvA = null;
     srvB.close();
     srvB = null;
   });
-  
+
   describe('ca server', function () {
     it('should generate a root CA file', function (done) {
       fs.access(__dirname + '/../.http-mitm-proxy/certs/ca.pem', function (err) {
@@ -102,7 +101,7 @@ describe('proxy', function () {
       });
     });
   });
-  
+
   describe('http server', function () {
     describe('get a 1024 byte file', function () {
       it('a', function (done) {
@@ -125,7 +124,7 @@ describe('proxy', function () {
       });
     });
   });
-  
+
   describe('proxy server', function () {
     this.timeout(5000);
     describe('proxy a 1024 byte file', function () {
@@ -182,7 +181,7 @@ describe('proxy', function () {
           }
           return callback();
         });
-      
+
         proxyHttp(testUrlA + '/1024', function (err, resp, body) {
           if (err) return done(new Error(err.message+" "+JSON.stringify(err)));
           var len = 0;
@@ -205,5 +204,5 @@ describe('proxy', function () {
       });
     });
   });
-  
+
 });

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -5,6 +5,7 @@ var request = require('request');
 var fs = require('fs');
 var http = require('http');
 var nodeStatic = require('node-static');
+var WebSocket = require('ws');
 var Proxy = require('../');
 var fileStaticA = new nodeStatic.Server(__dirname + '/wwwA');
 var fileStaticB = new nodeStatic.Server(__dirname + '/wwwB');
@@ -13,6 +14,7 @@ var testHostName = 'localhost';
 var testPortA = 40005;
 var testPortB = 40006;
 var testProxyPort = 40010;
+var testWSPort = 40007;
 var testUrlA = 'http://' + testHost + ':' + testPortA;
 var testUrlB = 'http://' + testHost + ':' + testPortB;
 
@@ -24,7 +26,7 @@ var getHttp = function (url, cb) {
 
 var proxyHttp = function (url, cb) {
   request({ url: url, proxy: 'http://127.0.0.1:' + testProxyPort, ca: fs.readFileSync(__dirname + '/../.http-mitm-proxy/certs/ca.pem') }, function (err, resp, body) {
-	cb(err, resp, body);
+	  cb(err, resp, body);
   });
 };
 
@@ -52,6 +54,8 @@ describe('proxy', function () {
   var testFiles = [
     '1024'
   ];
+  var wss = null;
+
   before(function () {
     testFiles.forEach(function (val) {
       testHashes[val] = crypto.createHash('sha256').update(fs.readFileSync(__dirname + '/www/' + val, 'utf8'), 'utf8').digest().toString();
@@ -68,6 +72,15 @@ describe('proxy', function () {
       }).resume();
     });
     srvB.listen(testPortB, testHost);
+    wss = new WebSocket.Server({
+      port: testWSPort,
+    });
+    wss.on('connection', function (ws) {
+      // just reply with the same message
+      ws.on('message', function (message) {
+        ws.send(message);
+      });
+    });
   });
 
   beforeEach(function (done) {
@@ -85,6 +98,8 @@ describe('proxy', function () {
     srvA = null;
     srvB.close();
     srvB = null;
+    wss.close();
+    wss = null;
   });
 
   describe('ca server', function () {
@@ -161,7 +176,6 @@ describe('proxy', function () {
     describe('host match', function () {
       it('proxy and modify AAA 5 times if hostA', function (done) {
         proxy.onRequest(function (ctx, callback) {
-          // console.log(ctx.clientToProxyRequest.headers);
           var testHostNameA = '127.0.0.1:' + testPortA;
           if (ctx.clientToProxyRequest.headers.host === testHostNameA) {
             var chunks = [];
@@ -205,4 +219,91 @@ describe('proxy', function () {
     });
   });
 
+  describe('websocket server', function() {
+    this.timeout(2000);
+
+    it('send + receive message without proxy', function (done) {
+      var ws = new WebSocket('ws://localhost:' + testWSPort);
+      var testMessage = 'does the websocket server reply?';
+      ws.on('open', function () {
+        ws.on('message', function (data) {
+          assert.equal(data, testMessage);
+          ws.close();
+          done();
+        });
+        ws.send(testMessage);
+      });
+    });
+
+    it('send + receive message through proxy', function (done) {
+      var ws = new WebSocket('ws://localhost:' + testProxyPort, {
+        host: 'localhost:' + testWSPort,
+      });
+      var testMessage = 'does websocket proxying work?';
+      ws.on('open', function () {
+        ws.on('message', function (data) {
+          assert.equal(data, testMessage);
+          ws.close();
+          done();
+        });
+        ws.send(testMessage);
+      });
+    });
+
+    it('websocket callbacks get called', function (done) {
+      var stats = {
+        connection: false,
+        frame: false,
+        send: false,
+        message: false,
+        close: false,
+      };
+
+      proxy.onWebSocketConnection(function (ctx, callback) {
+        stats.connection = true;
+        return callback();
+      });
+      proxy.onWebSocketFrame(function(ctx, type, fromServer, message, flags, callback) {
+        stats.frame = true;
+        message = rewrittenMessage;
+        return callback(null, message, flags);
+      });
+      proxy.onWebSocketSend(function(ctx, message, flags, callback) {
+        stats.send = true;
+        return callback(null, message, flags);
+      });
+      proxy.onWebSocketMessage(function(ctx, message, flags, callback) {
+        stats.message = true;
+        return callback(null, message, flags);
+      });
+      proxy.onWebSocketClose(function(ctx, code, message, callback) {
+        stats.close = true;
+        callback(null, code, message);
+      });
+
+      var ws = new WebSocket('ws://localhost:' + testProxyPort, {
+        host: 'localhost:' + testWSPort,
+      });
+      var testMessage = 'does rewriting messages work?';
+      var rewrittenMessage = 'rewriting messages does work!';
+      ws.on('open', function () {
+        ws.on('message', function (data) {
+          assert.equal(data, rewrittenMessage);
+          ws.close();
+        });
+        ws.on('close', function () {
+          setTimeout(() => {
+            assert(stats.connection);
+            assert(stats.frame);
+            assert(stats.send);
+            assert(stats.message);
+            assert(stats.close);
+
+            done();
+          }, 0);
+        });
+        ws.send(testMessage);
+      });
+    });
+  });
 });


### PR DESCRIPTION
WebSocket proxying was broken in https://github.com/joeferner/node-http-mitm-proxy/commit/b59c010f65ba1fe6542ac01aab9230e15bbdd074. This fixes them, and adds a unit test that was failing, but now passes.