### PR TITLE
Include CONNECT headers in the contexts

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -63,6 +63,7 @@ Proxy.prototype.listen = function(options, callback) {
     self.ca = ca;
     self.sslServers = {};
     self.sslSemaphores = {};
+    self.connectHeaders = {};
     self.httpServer = http.createServer();
     self.httpServer.timeout = self.timeout;
     self.httpServer.on('connect', self._onHttpServerConnect.bind(self));
@@ -373,9 +374,12 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
     // open a TCP connection to the remote host
     var conn = net.connect(port, function() {
       // create a tunnel between the two hosts
+      var connectKey = conn.localPort + ':' + conn.remotePort;
+      self.connectHeaders[connectKey] = req.headers; 
       socket.pipe(conn);
       conn.pipe(socket);
       socket.emit('data', head);
+      conn.on('end', function() { delete self.connectHeaders[connectKey]; });
       return socket.resume();
     });
     conn.on('error', self._onError.bind(self, 'PROXY_TO_PROXY_SOCKET_ERROR', null));
@@ -527,6 +531,7 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws, upgradeReq) {
   var self = this;
   var ctx = {
     isSSL: isSSL,
+    connectHeaders: self.connectHeaders[ws._socket.remotePort + ':' + ws._socket.localPort] || {},
     clientToProxyWebSocket: ws,
     onWebSocketConnectionHandlers: [],
     onWebSocketFrameHandlers: [],
@@ -641,6 +646,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   var self = this;
   var ctx = {
     isSSL: isSSL,
+    connectHeaders: self.connectHeaders[clientToProxyRequest.socket.remotePort + ':' + clientToProxyRequest.socket.localPort] || {},
     clientToProxyRequest: clientToProxyRequest,
     proxyToClientResponse: proxyToClientResponse,
     onRequestHandlers: [],


### PR DESCRIPTION
This is an attempted solution for #73 and #74 related to authenticating HTTPS and websocket connections. 

You can indeed hook into the CONNECT process to return a 407 status and then get the client to send the proxy-authorization header as suggested in the comments of the above mentioned issues. 

The problem is that the headers sent during CONNECT are not associated with the request or websocket context in any way.

I'm not sure if my fix is ideal, but it seems to work well to ensure we can get the proxy credentials on each request and websocket connection.