### PR TITLE
Include entire CONNECT request in the contexts not just headers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -63,7 +63,7 @@ Proxy.prototype.listen = function(options, callback) {
     self.ca = ca;
     self.sslServers = {};
     self.sslSemaphores = {};
-    self.connectHeaders = {};
+    self.connectRequests = {};
     self.httpServer = http.createServer();
     self.httpServer.timeout = self.timeout;
     self.httpServer.on('connect', self._onHttpServerConnect.bind(self));
@@ -375,11 +375,11 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
     var conn = net.connect(port, function() {
       // create a tunnel between the two hosts
       var connectKey = conn.localPort + ':' + conn.remotePort;
-      self.connectHeaders[connectKey] = req.headers; 
+      self.connectRequests[connectKey] = req; 
       socket.pipe(conn);
       conn.pipe(socket);
       socket.emit('data', head);
-      conn.on('end', function() { delete self.connectHeaders[connectKey]; });
+      conn.on('end', function() { delete self.connectRequests[connectKey]; });
       return socket.resume();
     });
     conn.on('error', self._onError.bind(self, 'PROXY_TO_PROXY_SOCKET_ERROR', null));
@@ -531,7 +531,7 @@ Proxy.prototype._onWebSocketServerConnect = function(isSSL, ws, upgradeReq) {
   var self = this;
   var ctx = {
     isSSL: isSSL,
-    connectHeaders: self.connectHeaders[ws._socket.remotePort + ':' + ws._socket.localPort] || {},
+    connectRequest: self.connectRequests[ws._socket.remotePort + ':' + ws._socket.localPort] || {},
     clientToProxyWebSocket: ws,
     onWebSocketConnectionHandlers: [],
     onWebSocketFrameHandlers: [],
@@ -646,7 +646,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   var self = this;
   var ctx = {
     isSSL: isSSL,
-    connectHeaders: self.connectHeaders[clientToProxyRequest.socket.remotePort + ':' + clientToProxyRequest.socket.localPort] || {},
+    connectRequest: self.connectRequests[clientToProxyRequest.socket.remotePort + ':' + clientToProxyRequest.socket.localPort] || {},
     clientToProxyRequest: clientToProxyRequest,
     proxyToClientResponse: proxyToClientResponse,
     onRequestHandlers: [],


### PR DESCRIPTION
Sorry for changing this so quickly after my previous pull request :). I needed to be able to get access to the IP address of the requestor so I changed this to add the entire connect request to the context instead of just the headers. Seemed like something others might find useful as well.