### PR TITLE
replace console.logs with debug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,6 @@
          host?: string;
          /** - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')*/
          sslCaDir?: string;
-         /**  - if set to true, nothing will be written to console (default: false) */
-         silent?: boolean;
          /**  - enable HTTP persistent connection*/
          keepAlive?: boolean;
          /**  - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout. */
@@ -69,7 +67,6 @@
          // onRequestHandlers:((ctx,callback)=>void)[];
 
          options: IProxyOptions;
-         silent: boolean;
          httpPort: number;
          timeout: number;
          keepAlive: boolean;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -13,6 +13,7 @@ var url = require('url');
 var semaphore = require('semaphore');
 var ca = require('./ca.js');
 const nodeCommon = require('_http_common');
+const debug = require('debug')('http-mitm-proxy');
 
 module.exports = function() {
   return new Proxy();
@@ -43,7 +44,6 @@ module.exports.Proxy = Proxy;
 Proxy.prototype.listen = function(options, callback) {
   var self = this;
   this.options = options || {};
-  this.silent = !!options.silent;
   this.httpPort = options.port || 8080;
   this.httpHost = options.host;
   this.timeout = options.timeout || 0;
@@ -51,8 +51,8 @@ Proxy.prototype.listen = function(options, callback) {
   this.httpAgent = typeof(options.httpAgent) !== "undefined" ? options.httpAgent : new http.Agent({ keepAlive: this.keepAlive });
   this.httpsAgent = typeof(options.httpsAgent) !== "undefined" ? options.httpsAgent : new https.Agent({ keepAlive: this.keepAlive });
   this.forceSNI = !!options.forceSNI;
-  if (this.forceSNI && !this.silent) {
-    console.log('SNI enabled. Clients not supporting SNI may fail');
+  if (this.forceSNI) {
+    debug('SNI enabled. Clients not supporting SNI may fail');
   }
   this.httpsPort = this.forceSNI ? options.httpsPort : undefined;
   this.sslCaDir = options.sslCaDir || path.resolve(process.cwd(), '.http-mitm-proxy');
@@ -81,9 +81,7 @@ Proxy.prototype.listen = function(options, callback) {
     if (self.forceSNI) {
       // start the single HTTPS server now
       self._createHttpsServer({}, function(port, httpsServer, wssServer) {
-        if (!self.silent) {
-          console.log('https server started on '+port);
-        }
+        debug('https server started on '+port);
         self.httpsServer = httpsServer;
         self.wssServer = wssServer;
         self.httpsPort = port;
@@ -455,23 +453,17 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
         }
         delete results.httpsOptions.hosts;
         if (self.forceSNI && !hostname.match(/^[\d\.]+$/)) {
-          if (!self.silent) {
-            console.log('creating SNI context for ' + hostname);
-          }
+          debug('creating SNI context for ' + hostname);
           hosts.forEach(function(host) {
             self.httpsServer.addContext(host, results.httpsOptions);
             self.sslServers[host] = { port : self.httpsPort };
           });
           return callback(null, self.httpsPort);
         } else {
-          if (!self.silent) {
-            console.log('starting server for ' + hostname);
-          }
+          debug('starting server for ' + hostname);
           results.httpsOptions.hosts = hosts;
           self._createHttpsServer(results.httpsOptions, function(port, httpsServer, wssServer) {
-            if (!self.silent) {
-              console.log('https server started for %s on %s', hostname, port);
-            }
+            debug('https server started for %s on %s', hostname, port);
             var sslServer = {
               server: httpsServer,
               wsServer: wssServer,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "async": "^2.5.0",
+    "debug": "^4.1.0",
     "mkdirp": "^0.5.1",
     "node-forge": "^0.7.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
`debug` is the defacto standard for logging in Node.js.

This replaces the `silent` option. To see output, enable `http-mitm-proxy` with env variable:

```
$ DEBUG=http-mitm-proxy node myproxy.js
```