### PR TITLE
Using port 0 to listen on arbitrary unused port

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -44,7 +44,7 @@ module.exports.Proxy = Proxy;
 Proxy.prototype.listen = function(options, callback) {
   var self = this;
   this.options = options || {};
-  this.httpPort = options.port || 8080;
+  this.httpPort = options.port || options.port === 0 ? options.port : 8080;
   this.httpHost = options.host;
   this.timeout = options.timeout || 0;
   this.keepAlive = !!options.keepAlive;
@@ -85,10 +85,16 @@ Proxy.prototype.listen = function(options, callback) {
         self.httpsServer = httpsServer;
         self.wssServer = wssServer;
         self.httpsPort = port;
-        self.httpServer.listen(listenOptions, callback);
+        self.httpServer.listen(listenOptions, () => {
+          self.httpPort = self.httpServer.address().port;
+          callback();
+	});
       });
     } else {
-      self.httpServer.listen(listenOptions, callback);
+      self.httpServer.listen(listenOptions, () => {
+        self.httpPort = self.httpServer.address().port;
+        callback();
+      });
     }
   });
   return this;


### PR DESCRIPTION
```js
const proxy = require('http-mitm-proxy')()
proxy.listen({ port: 0 }, () => console.log('Proxy server is listening on port', proxy.httpPort))
```