### PR TITLE
Safer handling of chunked transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 npm-debug.log
 .idea
 .http-mitm-proxy
+.vscode

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -37,6 +37,7 @@ var Proxy = function() {
   this.onResponseHeadersHandlers = [];
   this.onResponseDataHandlers = [];
   this.onResponseEndHandlers = [];
+  this.responseContentPotentiallyModified = false;
 };
 
 module.exports.Proxy = Proxy;
@@ -233,6 +234,7 @@ Proxy.prototype.onResponseHeaders = function(fn) {
 
 Proxy.prototype.onResponseData = function(fn) {
   this.onResponseDataHandlers.push(fn);
+  this.responseContentPotentiallyModified = true;
   return this;
 };
 
@@ -672,6 +674,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     onResponseEndHandlers: [],
     requestFilters: [],
     responseFilters: [],
+    responseContentPotentiallyModified: false,
     onRequest: function(fn) {
       ctx.onRequestHandlers.push(fn);
       return ctx;
@@ -698,6 +701,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     },
     onResponseData: function(fn) {
       ctx.onResponseDataHandlers.push(fn);
+      ctx.responseContentPotentiallyModified = true;
       return ctx;
     },
     onResponseEnd: function(fn) {
@@ -706,6 +710,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
     },
     addResponseFilter: function(filter) {
       ctx.responseFilters.push(filter);
+      ctx.responseContentPotentiallyModified = true;
       return ctx;
     },
     use: function(mod) {
@@ -787,7 +792,7 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
       if (err) {
         return self._onError('ON_RESPONSE_ERROR', ctx, err);
       }
-      if (ctx.responseFilters.length > 0) {
+      if (self.responseContentPotentiallyModified || ctx.responseContentPotentiallyModified) {
         ctx.serverToProxyResponse.headers['transfer-encoding'] = 'chunked';
         delete ctx.serverToProxyResponse.headers['content-length'];  
       }


### PR DESCRIPTION
After further consideration, my last PR was a bit too optimistic. 
This PR checks if onResponseData, ctx.onResponseData or ctx.addResponseFilter have been used to determine if chunked encoding needs to be applied. The response content might be modified through any of these methods.
Also added unit tests to verify the logic.