### PR TITLE
Close callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 npm-debug.log
 .idea
 .http-mitm-proxy
+.vscode

--- a/README.md
+++ b/README.md
@@ -137,11 +137,17 @@ __Example__
 
 ### proxy.close
 
-Stops the proxy listening.
+Stops the proxy listening. This function is async - it will not wait for ongoing connections to close. Use the callback variant to get notified when all connections have been closed.
 
-__Example__
+__Example 1__
 
     proxy.close();
+
+__Example 2: Closed callback__
+
+    proxy.close(function (error) {
+      console.log('All connections have been closed');
+    });
 
 <a name="proxy_onError" />
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,8 +45,8 @@
         
          Example
         
-         proxy.close(); */
-         close(): void;
+         proxy.close((error) => void); */
+         close(callback?: (error?: Error) => void): void;
 
 
          onCertificateRequired(hostname: string, callback: (error: Error | undefined, certDetails: { keyFile: string; certFile: string; hosts: string[]; }) => void): void;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -132,12 +132,15 @@ Proxy.prototype._createHttpsServer = function (options, callback) {
   httpsServer.listen.apply(httpsServer, listenArgs);
 };
 
-Proxy.prototype.close = function () {
+Proxy.prototype.close = function (callback) {
   var self = this;
-  this.httpServer.close();
-  delete this.httpServer;
+  var awaitCallbacks = 0;
+  if (this.httpServer) {
+    closeAndCallback(this.httpServer, callback);
+    delete this.httpServer;
+  }
   if (this.httpsServer) {
-    this.httpsServer.close();
+    closeAndCallback(this.httpsServer, callback);
     delete this.httpsServer;
     delete this.wssServer;
     delete this.sslServers;
@@ -145,11 +148,31 @@ Proxy.prototype.close = function () {
   if (this.sslServers) {
     (Object.keys(this.sslServers)).forEach(function (srvName) {
       var server = self.sslServers[srvName].server;
-      if (server) server.close();
+      if (server) {
+        closeAndCallback(server, callback);
+      }
       delete self.sslServers[srvName];
     });
   }
   return this;
+
+  function closeAndCallback(server, callback) {
+    if (callback) {
+      awaitCallbacks++;
+      server.close(function (err) {
+        if (err) {
+          callback(err);
+        }
+        awaitCallbacks--;
+        if (awaitCallbacks === 0) {
+          debug('all servers closed');
+          callback();
+        }
+      });  
+    } else {
+      server.close();
+    }
+  }
 };
 
 Proxy.prototype.onError = function(fn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
@@ -323,6 +332,21 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -519,6 +543,27 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -652,6 +697,12 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "keepalive-proxy-agent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keepalive-proxy-agent/-/keepalive-proxy-agent-1.0.1.tgz",
+      "integrity": "sha512-GtDNPtdD6JPC2n9E5mIil21ryvz0jlZ4lYKItRKXk+Z0KShuih/LG7xccrxmYwbgxZ0xIvJZDZ9DNGAv2KT+EQ==",
+      "dev": true
     },
     "lcid": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
-    },
     "ajv": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
@@ -332,21 +323,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -541,27 +517,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "inflight": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "https-proxy-agent": "^2.2.1",
+    "keepalive-proxy-agent": "^1.0.1",
     "mocha": "^6.1.4",
     "node-static": "^0.7.10",
     "request": "^2.83.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "https-proxy-agent": "^2.2.1",
     "keepalive-proxy-agent": "^1.0.1",
     "mocha": "^6.1.4",
     "node-static": "^0.7.10",


### PR DESCRIPTION
To allow a graceful shutdown, it is quite convenient to get a callback when proxy.close has managed to close all connections. Since the function is async there is currently no way to determine when close has actually completed. With this callback this is now possible.

The PR also fixes the issue that multiple calls to proxy.close threw errors.

Added a devDependency on keepalive-proxy-agent, since the request package couldn't handle keep-alive when proxying to https sites (through a tunnel). This was required for proper unit testing.

General: Improved unit tests of keep-alive scenarios, I found that the keep-alive option of the proxy itself wasn't used in the unit tests.