### PR TITLE
Https socket close

### DIFF
--- a/examples/forwardHttps.js
+++ b/examples/forwardHttps.js
@@ -19,6 +19,9 @@ proxy.onConnect(function(req, socket, head) {
     conn.on('finish', () => {
       socket.destroy();
     });
+    socket.on('close', () => {
+      conn.end();
+    });
     socket.write('HTTP/1.1 200 OK\r\n\r\n', 'UTF-8', function(){
       conn.pipe(socket);
       socket.pipe(conn);
@@ -54,6 +57,6 @@ proxy.listen({ port }, function() {
     }
     console.log(`${stdout}`);
     assert(/DOCTYPE/.test(stdout));
-    process.exit()
+    proxy.close();
   });
 });

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -386,6 +386,9 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
       conn.on('finish', () => {
         socket.destroy();
       });
+      socket.on('close', () => {
+        conn.end();
+      });
       var connectKey = conn.localPort + ':' + conn.remotePort;
       self.connectRequests[connectKey] = req; 
       socket.pipe(conn);

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -266,7 +266,7 @@ describe('proxy', function () {
     });
 
     describe('chunked transfer', function () {
-      it('should not change transfer encoding when no content modification is active', function () {
+      it('should not change transfer encoding when no content modification is active', function (done) {
         proxyHttp(testUrlA + '/1024.bin', false, function (err, resp, body) {
           if (err) return done(new Error(err.message+" "+JSON.stringify(err)));
           var len = 0;
@@ -274,10 +274,11 @@ describe('proxy', function () {
           assert.equal(1024, len);
           assert.equal(null, resp.headers['transfer-encoding']);
           assert.equal(1024, resp.headers['content-length']);
+          done();
         });
       });
 
-      it('should use chunked transfer encoding when global onResponseData is active', function () {
+      it('should use chunked transfer encoding when global onResponseData is active', function (done) {
         proxy.onResponseData(function (ctx, chunk, callback) {
           callback(null, chunk);
         });
@@ -288,10 +289,11 @@ describe('proxy', function () {
           assert.equal(1024, len);
           assert.equal('chunked', resp.headers['transfer-encoding']);
           assert.equal(null, resp.headers['content-length']);
+          done();
         });
       });
 
-      it('should use chunked transfer encoding when context onResponseData is active', function () {
+      it('should use chunked transfer encoding when context onResponseData is active', function (done) {
         proxy.onResponse(function (ctx, callback) {
           ctx.onResponseData(function (ctx, chunk, callback) {
             callback(null, chunk);
@@ -305,10 +307,11 @@ describe('proxy', function () {
           assert.equal(1024, len);
           assert.equal('chunked', resp.headers['transfer-encoding']);
           assert.equal(null, resp.headers['content-length']);
+          done();
         });
       });
 
-      it('should use chunked transfer encoding when context ResponseFilter is active', function () {
+      it('should use chunked transfer encoding when context ResponseFilter is active', function (done) {
         proxy.onResponse(function (ctx, callback) {
           ctx.addResponseFilter(zlib.createGzip());
           callback(null);
@@ -320,6 +323,7 @@ describe('proxy', function () {
           assert.equal(true, len < 1024); // Compressed body
           assert.equal('chunked', resp.headers['transfer-encoding']);
           assert.equal(null, resp.headers['content-length']);
+          done();
         });
       });
     });


### PR DESCRIPTION
When using this proxy for https sites in keep-alive scenarios I found that my application would not exit, since there were still open connections even after calling proxy.close(). 

This PR makes sure that tunnels to "internal" https proxy servers are properly closed when the client disconnects. 
Also updated the example code for direct tunnels (forwardHttps) and some minor fixes to unit tests.

If this PR is accepted, please make a new npm release. I have another project which uses this library and would prefer to reference a released version rather than a github link in package.json. Thanks in advance.