### PR TITLE
Switch server certificates to 2048 bits

### DIFF
--- a/lib/ca.js
+++ b/lib/ca.js
@@ -198,7 +198,7 @@ CA.prototype.generateServerCertificateKeys = function (hosts, cb) {
   var self = this;
   if (typeof(hosts) === "string") hosts = [hosts];
   var mainHost = hosts[0];
-  var keysServer = pki.rsa.generateKeyPair(1024);
+  var keysServer = pki.rsa.generateKeyPair(2048);
   var certServer = pki.createCertificate();
   certServer.publicKey = keysServer.publicKey;
   certServer.serialNumber = this.randomSerialNumber();

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -185,7 +185,7 @@ describe('proxy', function () {
           assert.equal(200, resp.statusCode, '200 Status code from Google.');
           done();
         });
-      });
+      }).timeout(10000);
     });
 
     describe('proxy a 1024 byte file with keepAlive', function () {
@@ -217,7 +217,7 @@ describe('proxy', function () {
           assert.equal(200, resp.statusCode, '200 Status code from Google.');
           done();
         });
-      });
+      }).timeout(10000);
     });
 
     describe('host match', function () {


### PR DESCRIPTION
Using 1024 bit server certificates causes App Transport Security failures on iOS when perfect forward security (PFS) is enabled. This doesn't manifest in all cases (e.g. browsing using Safari works fine with the proxy enabled and 1024 keys) but does show up when testing with `nscurl --ats-diagnostics`.

With 1024 bit, PFS enabled:

```
Default ATS Secure Connection
---
ATS Default Connection
ATS Dictionary:
{
}
2019-07-12 10:47:23.171 nscurl[55346:1341935] NSURLSession/NSURLConnection HTTP load failed (kCFStreamErrorDomainSSL, -9802)
Result : FAIL
Error : Error Domain=NSURLErrorDomain Code=-1200 "An SSL error has occurred and a secure connection to the server cannot be made." UserInfo={NSLocalizedRecoverySuggestion=Would you like to connect to the server anyway?, _kCFStreamErrorDomainKey=3, NSErrorPeerCertificateChainKey=(
    "<cert(0x7ff97d815e00) s: *.example.com i: NodeMITMProxyCA>"
), NSErrorClientCertificateStateKey=0, NSErrorFailingURLKey=https://example.com/, NSErrorFailingURLStringKey=https://example.com/, NSUnderlyingError=0x7ff97ce23d50 {Error Domain=kCFErrorDomainCFNetwork Code=-1200 "(null)" UserInfo={_kCFStreamPropertySSLClientCertificateState=0, kCFStreamPropertySSLPeerTrust=<SecTrustRef: 0x7ff97cc0b8c0>, _kCFNetworkCFStreamSSLErrorOriginalValue=-9802, _kCFStreamErrorDomainKey=3, _kCFStreamErrorCodeKey=-9802, kCFStreamPropertySSLPeerCertificates=(
    "<cert(0x7ff97d815e00) s: *.example.com i: NodeMITMProxyCA>"
)}}, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <C2A0CB78-3872-413C-BF80-193B0C434270>.<1>"
), _kCFStreamErrorCodeKey=-9802, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <C2A0CB78-3872-413C-BF80-193B0C434270>.<1>, NSURLErrorFailingURLPeerTrustErrorKey=<SecTrustRef: 0x7ff97cc0b8c0>, NSLocalizedDescription=An SSL error has occurred and a secure connection to the server cannot be made.}
---
```

With 1024 bit, PFS disabled:

```
---
ATS with user-defined values

ATS Dictionary:
{
    NSExceptionDomains =     {
        "example.com" =         {
            NSExceptionRequiresForwardSecrecy = false;
        };
    };
}
Result : PASS
---
```

With 2048 bit, PFS enabled:

```
Default ATS Secure Connection
---
ATS Default Connection
ATS Dictionary:
{
}
Result : PASS
---
```