### PR TITLE
Handle socket errors in CONNECT method negotiation

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -301,8 +301,19 @@ Proxy.prototype.use = function(mod) {
   return this;
 };
 
+// Since node 0.9.9, ECONNRESET on sockets are no longer hidden
+Proxy.prototype._onSocketError = function(socketDescription, err) {
+  if (err.errno === 'ECONNRESET') {
+    debug('Got ECONNRESET on ' + socketDescription + ', ignoring.');
+  } else {
+    this._onError(socketDescription + '_ERROR', null, err);
+  }
+};
+
 Proxy.prototype._onHttpServerConnect = function(req, socket, head) {
   var self = this;
+
+  socket.on('error', self._onSocketError.bind(self, 'CLIENT_TO_PROXY_SOCKET'));
 
   // you can forward HTTPS request directly by adding custom CONNECT method handler
   return async.forEach(self.onConnectHandlers, function (fn, callback) {
@@ -397,17 +408,7 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
       conn.on('end', function() { delete self.connectRequests[connectKey]; });
       return socket.resume();
     });
-    conn.on('error', function(err) { filterSocketConnReset(err, 'PROXY_TO_PROXY_SOCKET'); });
-    socket.on('error', function(err) { filterSocketConnReset(err, 'CLIENT_TO_PROXY_SOCKET'); });
-  }
-
-  // Since node 0.9.9, ECONNRESET on sockets are no longer hidden
-  function filterSocketConnReset(err, socketDescription) {
-    if (err.errno === 'ECONNRESET') {
-      debug('Got ECONNRESET on ' + socketDescription + ', ignoring.');
-    } else {
-      self._onError(socketDescription + '_ERROR', null, err);
-    }
+    conn.on('error', self._onSocketError.bind(self, 'PROXY_TO_PROXY_SOCKET'));
   }
 
   function getHttpsServer(hostname, callback) {

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -5,6 +5,7 @@ var zlib = require('zlib');
 var request = require('request');
 var fs = require('fs');
 var http = require('http');
+var net = require('net');
 var nodeStatic = require('node-static');
 var WebSocket = require('ws');
 var Proxy = require('../');
@@ -156,6 +157,30 @@ describe('proxy', function () {
 
   describe('proxy server', function () {
     this.timeout(5000);
+
+    it('should handle socket errors in connect', function(done) {
+      // If a socket disconnects during the CONNECT process, the resulting
+      // error should be handled and shouldn't cause the proxy server to fail.
+      const socket = net.createConnection(testProxyPort, testHost, function() {
+        socket.write('CONNECT ' + testHost + ':' + testPortA + '\r\n\r\n');
+        socket.destroy();
+      });
+      socket.on('close', function() {
+        proxyHttp(testUrlA + '/1024.bin', false, function (err, resp, body) {
+          if (err) {
+            return done(new Error(err.message + " " + JSON.stringify(err)));
+          }
+          var len = 0;
+          if (body.hasOwnProperty('length')) {
+            len = body.length;
+          }
+          assert.equal(1024, len);
+          assert.equal(testHashes['1024.bin'], crypto.createHash('sha256').update(body, 'utf8').digest().toString());
+          done();
+        });
+      })
+    });
+
     describe('proxy a 1024 byte file', function () {
       it('a', function (done) {
         proxyHttp(testUrlA + '/1024.bin', false, function (err, resp, body) {

--- a/test/01_proxy.js
+++ b/test/01_proxy.js
@@ -210,7 +210,7 @@ describe('proxy', function () {
           assert.equal(200, resp.statusCode, '200 Status code from Google.');
           done();
         });
-      }).timeout(10000);
+      }).timeout(15000);
     });
 
     describe('proxy a 1024 byte file with keepAlive', function () {
@@ -242,7 +242,7 @@ describe('proxy', function () {
           assert.equal(200, resp.statusCode, '200 Status code from Google.');
           done();
         });
-      }).timeout(10000);
+      }).timeout(15000);
     });
 
     describe('host match', function () {


### PR DESCRIPTION
When initially establishing a CONNECT tunnel, if the socket has an error before makeConnection attaches the error handler it can result in an unhandler error event bubbling up and killing the node process. This pull attaches the socket error handler sooner to handle this.