### PR TITLE
Update proxy.js - Absence of HOST in headers

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -744,36 +744,44 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   ctx.proxyToClientResponse.on('error', self._onError.bind(self, 'PROXY_TO_CLIENT_RESPONSE_ERROR', ctx));
   ctx.clientToProxyRequest.pause();
   var hostPort = Proxy.parseHostAndPort(ctx.clientToProxyRequest, ctx.isSSL ? 443 : 80);
-  var headers = {};
-  for (var h in ctx.clientToProxyRequest.headers) {
-    // don't forward proxy- headers
-    if (!/^proxy\-/i.test(h)) {
-      headers[h] = ctx.clientToProxyRequest.headers[h];
-    }
-  }
-  if (this.options.forceChunkedRequest){
-    delete headers['content-length'];
-  }
-
-  ctx.proxyToServerRequestOptions = {
-    method: ctx.clientToProxyRequest.method,
-    path: ctx.clientToProxyRequest.url,
-    host: hostPort.host,
-    port: hostPort.port,
-    headers: headers,
-    agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
-  };
-  return self._onRequest(ctx, function(err) {
-    if (err) {
-      return self._onError('ON_REQUEST_ERROR', ctx, err);
-    }
-    return self._onRequestHeaders(ctx, function(err) {
-      if (err) {
-        return self._onError('ON_REQUESTHEADERS_ERROR', ctx, err);
-      }
-      return makeProxyToServerRequest();
+  if (hostPort === null) {
+    ctx.clientToProxyRequest.resume();
+    ctx.proxyToClientResponse.writeHeader(400, {
+      'Content-Type': 'text/html; charset=utf-8'
     });
-  });
+    ctx.proxyToClientResponse.end('Bad request: Host missing...', 'UTF-8');
+  } else {
+    var headers = {};
+    for (var h in ctx.clientToProxyRequest.headers) {
+      // don't forward proxy- headers
+      if (!/^proxy\-/i.test(h)) {
+        headers[h] = ctx.clientToProxyRequest.headers[h];
+      }
+    }
+    if (this.options.forceChunkedRequest){
+      delete headers['content-length'];
+    }
+
+    ctx.proxyToServerRequestOptions = {
+      method: ctx.clientToProxyRequest.method,
+      path: ctx.clientToProxyRequest.url,
+      host: hostPort.host,
+      port: hostPort.port,
+      headers: headers,
+      agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
+    };
+    return self._onRequest(ctx, function(err) {
+      if (err) {
+        return self._onError('ON_REQUEST_ERROR', ctx, err);
+      }
+      return self._onRequestHeaders(ctx, function(err) {
+        if (err) {
+          return self._onError('ON_REQUESTHEADERS_ERROR', ctx, err);
+        }
+        return makeProxyToServerRequest();
+      });
+    });
+  }
 
   function makeProxyToServerRequest() {
     var proto = ctx.isSSL ? https : http;


### PR DESCRIPTION
In the absence of a HOST in the request headers , the MITM **crashes**.
  
The "_parseHostAndPort_" function returns NULL if the HOST does not exist in the headers.

When the result is NULL, the MITM generates an error and **EXIT**.

The MITM should either 1) display an error message and continue to run normally or 2) send a 400 response to the client.

The changes made in this pullrequest (on "__onHttpServerRequest_" function) helps to better manage the absence of a HOST in the headers of a request.