### PR TITLE
Update proxy.js - Problem with url.parse(req.url)

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -744,44 +744,36 @@ Proxy.prototype._onHttpServerRequest = function(isSSL, clientToProxyRequest, pro
   ctx.proxyToClientResponse.on('error', self._onError.bind(self, 'PROXY_TO_CLIENT_RESPONSE_ERROR', ctx));
   ctx.clientToProxyRequest.pause();
   var hostPort = Proxy.parseHostAndPort(ctx.clientToProxyRequest, ctx.isSSL ? 443 : 80);
-  if (hostPort === null) {
-    ctx.clientToProxyRequest.resume();
-    ctx.proxyToClientResponse.writeHeader(400, {
-      'Content-Type': 'text/html; charset=utf-8'
-    });
-    ctx.proxyToClientResponse.end('Bad request: Host missing...', 'UTF-8');
-  } else {
-    var headers = {};
-    for (var h in ctx.clientToProxyRequest.headers) {
-      // don't forward proxy- headers
-      if (!/^proxy\-/i.test(h)) {
-        headers[h] = ctx.clientToProxyRequest.headers[h];
-      }
+  var headers = {};
+  for (var h in ctx.clientToProxyRequest.headers) {
+    // don't forward proxy- headers
+    if (!/^proxy\-/i.test(h)) {
+      headers[h] = ctx.clientToProxyRequest.headers[h];
     }
-    if (this.options.forceChunkedRequest){
-      delete headers['content-length'];
-    }
-
-    ctx.proxyToServerRequestOptions = {
-      method: ctx.clientToProxyRequest.method,
-      path: ctx.clientToProxyRequest.url,
-      host: hostPort.host,
-      port: hostPort.port,
-      headers: headers,
-      agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
-    };
-    return self._onRequest(ctx, function(err) {
-      if (err) {
-        return self._onError('ON_REQUEST_ERROR', ctx, err);
-      }
-      return self._onRequestHeaders(ctx, function(err) {
-        if (err) {
-          return self._onError('ON_REQUESTHEADERS_ERROR', ctx, err);
-        }
-        return makeProxyToServerRequest();
-      });
-    });
   }
+  if (this.options.forceChunkedRequest){
+    delete headers['content-length'];
+  }
+
+  ctx.proxyToServerRequestOptions = {
+    method: ctx.clientToProxyRequest.method,
+    path: ctx.clientToProxyRequest.url,
+    host: hostPort.host,
+    port: hostPort.port,
+    headers: headers,
+    agent: ctx.isSSL ? self.httpsAgent : self.httpAgent
+  };
+  return self._onRequest(ctx, function(err) {
+    if (err) {
+      return self._onError('ON_REQUEST_ERROR', ctx, err);
+    }
+    return self._onRequestHeaders(ctx, function(err) {
+      if (err) {
+        return self._onError('ON_REQUESTHEADERS_ERROR', ctx, err);
+      }
+      return makeProxyToServerRequest();
+    });
+  });
 
   function makeProxyToServerRequest() {
     var proto = ctx.isSSL ? https : http;
@@ -1080,22 +1072,15 @@ Proxy.prototype._onResponseEnd = function(ctx, callback) {
 };
 
 Proxy.parseHostAndPort = function(req, defaultPort) {
-  var host = req.headers.host;
-  if (!host) {
+  var m = req.url.match(/^http:\/\/([^\/]+)(.*)/);
+  if (m) {
+    req.url = m[2] || '/';
+    return Proxy.parseHost(m[1], defaultPort);
+  } else if (req.headers.host) {
+    return Proxy.parseHost(req.headers.host, defaultPort);
+  } else {
     return null;
   }
-  var hostPort = Proxy.parseHost(host, defaultPort);
-
-  // this handles paths which include the full url. This could happen if it's a proxy
-  var m = req.url.match(/^http:\/\/([^\/]*)\/?(.*)$/);
-  if (m) {
-    var parsedUrl = url.parse(req.url);
-    hostPort.host = parsedUrl.hostname;
-    hostPort.port = parsedUrl.port;
-    req.url = parsedUrl.path;
-  }
-
-  return hostPort;
 };
 
 Proxy.parseHost = function(hostString, defaultPort) {


### PR DESCRIPTION
In the MITM, urls containing a **simple quote** are not encoded in the same way when it's http or https :

- **http** request : the MITM encodes the simple quote and replace it with %27.
- **https** request : the MITM does not encode the simple quote.

The problem is `url.parse(req.url)` used in the **parseHostAndPort** function when it is a http request. `parse()` replaces the simple quote with %27.

I have rewritten the function **parseHostAndPort** so that it no longer uses the `parse()` method to get host and port. I use the regular expression instead to get them.