### PR TITLE
Reduce validity period to 2 years

### DIFF
--- a/lib/ca.js
+++ b/lib/ca.js
@@ -154,7 +154,7 @@ CA.prototype.generateCA = function (callback) {
     cert.validity.notBefore = new Date();
     cert.validity.notBefore.setDate(cert.validity.notBefore.getDate() - 1);
     cert.validity.notAfter = new Date();
-    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 10);
+    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 2);
     cert.setSubject(CAattrs);
     cert.setIssuer(CAattrs);
     cert.setExtensions(CAextensions);


### PR DESCRIPTION
This satisfies the new requirements in iOS 13 and Catalina for trusted certificates.

Fixes #208.