### PR TITLE
Fix big memory leak

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -382,6 +382,7 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
         }
         return makeConnection(port);
       });
+      delete self.sslSemaphores[wildcardHost];
     });
   } else {
     return makeConnection(this.httpPort);
@@ -394,18 +395,22 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
       allowHalfOpen: true
     }, function() {
       // create a tunnel between the two hosts
-      conn.on('finish', () => {
+      var connectKey = conn.localPort + ':' + conn.remotePort;
+      self.connectRequests[connectKey] = req;
+      const cleanupFunction = function() {
+        delete self.connectRequests[connectKey];
+      };
+      conn.on('close', () => {
+        cleanupFunction();
         socket.destroy();
       });
       socket.on('close', () => {
-        conn.end();
+        conn.destroy();
       });
-      var connectKey = conn.localPort + ':' + conn.remotePort;
-      self.connectRequests[connectKey] = req; 
+      conn.on('error', () => conn.destroy());
       socket.pipe(conn);
       conn.pipe(socket);
       socket.emit('data', head);
-      conn.on('end', function() { delete self.connectRequests[connectKey]; });
       return socket.resume();
     });
     conn.on('error', self._onSocketError.bind(self, 'PROXY_TO_PROXY_SOCKET'));


### PR DESCRIPTION
connectRequests were not properly freed, errors were not handled correctly.
Since this is a duplex stream, the connection needs to be closed manually on error.
sslSemaphores were not being deleted at all.
Please notice that the deletion of semaphores can be done better, a comment on this would be great.