### PR TITLE
Fix websocket close code propagation

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -974,7 +974,7 @@ Proxy.prototype._onWebSocketClose = function(ctx, closedByServer, code, message)
     ctx.closedByClient = !closedByServer;
     async.forEach(this.onWebSocketCloseHandlers.concat(ctx.onWebSocketCloseHandlers), function(fn, callback) {
       return fn(ctx, code, message, callback);
-    }, function(err, code, message) {
+    }, function(err) {
       if (err) {
         return self._onWebSocketError(ctx, err);
       }


### PR DESCRIPTION
 - the `async` library does not allow additional parameters in the callback  
 - parameters have the value `undefined`  
 - see https://caolan.github.io/async/v3/docs.html#each  
 - this PR uses the parent scope values instead  
 - fixes #220  