### PR TITLE
Default listen on 'localhost'

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ __Arguments__
 
  * options - An object with the following options:
   * port - The port or named socket to listen on (default: 8080).
-  * host - The hostname or local address to listen on.
+  * host - The hostname or local address to listen on (default: 'localhost'). Pass '::' to listen on all IPv4/IPv6 interfaces.
   * sslCaDir - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')
   * keepAlive - enable [HTTP persistent connection](https://en.wikipedia.org/wiki/HTTP_persistent_connection)
   * timeout - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout.

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -46,7 +46,7 @@ Proxy.prototype.listen = function(options, callback = e => {}) {
   var self = this;
   this.options = options || {};
   this.httpPort = options.port || options.port === 0 ? options.port : 8080;
-  this.httpHost = options.host;
+  this.httpHost = options.host || 'localhost';
   this.timeout = options.timeout || 0;
   this.keepAlive = !!options.keepAlive;
   this.httpAgent = typeof(options.httpAgent) !== "undefined" ? options.httpAgent : new http.Agent({ keepAlive: this.keepAlive });


### PR DESCRIPTION
Quoting Node `server.listen` [documentation](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback)
  > If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
  > In most operating systems, listening to the unspecified IPv6 address (::) may cause the net.Server to also listen on the unspecified IPv4 address (0.0.0.0).

The broad bind to all interfaces is an insecure default, so better the user/developer provide explicit confirmation of this configuration.

---

Follows https://github.com/joeferner/node-http-mitm-proxy/pull/147#issuecomment-346997595 suggestion