### PR TITLE
Reduce generated server cert validity period to 1y

### DIFF
--- a/lib/ca.ts
+++ b/lib/ca.ts
@@ -282,7 +282,7 @@ export class CA {
     );
     certServer.validity.notAfter = new Date();
     certServer.validity.notAfter.setFullYear(
-      certServer.validity.notBefore.getFullYear() + 2
+      certServer.validity.notBefore.getFullYear() + 1
     );
     const attrsServer = ServerAttrs.slice(0);
     attrsServer.unshift({


### PR DESCRIPTION
Certificates generated after 2020-09-01 with validity longer than 398 days will generate `ERR_CERT_VALIDITY_TOO_LONG` error in all major browsers ([Chrome](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/certificate_lifetimes.md), [Firefox](https://blog.mozilla.org/security/2020/07/09/reducing-tls-certificate-lifespans-to-398-days/), [Safari](https://support.apple.com/en-us/HT211025)).

This PR reduces the validity period from 2 years to 1 year.  
Note that the CA is still valid for 2 years — and this should be fine.