### PR TITLE
Optimize performance

### DIFF
--- a/lib/ca.js
+++ b/lib/ca.js
@@ -198,7 +198,7 @@ CA.prototype.generateServerCertificateKeys = function (hosts, cb) {
   var self = this;
   if (typeof(hosts) === "string") hosts = [hosts];
   var mainHost = hosts[0];
-  var keysServer = pki.rsa.generateKeyPair(2048);
+  var keysServer = this.CAkeys;
   var certServer = pki.createCertificate();
   certServer.publicKey = keysServer.publicKey;
   certServer.serialNumber = this.randomSerialNumber();
@@ -228,12 +228,6 @@ CA.prototype.generateServerCertificateKeys = function (hosts, cb) {
   var keyPublicPem = pki.publicKeyToPem(keysServer.publicKey)
   FS.writeFile(this.certsFolder + '/' + mainHost.replace(/\*/g, '_') + '.pem', certPem, function(error) {
     if (error) console.error("Failed to save certificate to disk in "+self.certsFolder, error);
-  });
-  FS.writeFile(this.keysFolder + '/' + mainHost.replace(/\*/g, '_') + '.key', keyPrivatePem, function(error) {
-    if (error) console.error("Failed to save private key to disk in "+self.keysFolder, error);
-  });
-  FS.writeFile(this.keysFolder + '/' + mainHost.replace(/\*/g, '_') + '.public.key', keyPublicPem, function(error) {
-    if (error) console.error("Failed to save public key to disk in "+self.keysFolder, error);
   });
   // returns synchronously even before files get written to disk
   cb(certPem, keyPrivatePem);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -520,7 +520,7 @@ Proxy.prototype._onHttpServerConnectData = function(req, socket, head) {
 Proxy.prototype.onCertificateRequired = function (hostname, callback) {
   var self = this;
   return callback(null, {
-    keyFile: self.sslCaDir + '/keys/' + hostname + '.key',
+    keyFile: self.sslCaDir + '/keys/ca.private.key',
     certFile: self.sslCaDir + '/certs/' + hostname + '.pem',
     hosts: [hostname]
   });


### PR DESCRIPTION
rsa private key generation will requires a lot of CPU performance.
using the fixed CA private key to generate a user certificate can optimize the first-time loading performance.