### PR TITLE
fix: websocket binary frame handling

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1207,7 +1207,7 @@ export class Proxy implements IProxy {
         if (destWebSocket.readyState === WebSocket.OPEN) {
           switch (type) {
             case "message":
-              destWebSocket.send(data, flags as WebSocketFlags);
+              destWebSocket.send(data, {binary: flags as boolean});
               break;
             case "ping":
               destWebSocket.ping(data, flags as boolean);


### PR DESCRIPTION
The callback parameters for `socket.on("message")` changed in [this commit](https://github.com/websockets/ws/commit/e173423c180dc1e4e6ee8938d9e4376a7a8b9757) and so `flags` is actually just indicating whether the frame is binary or ASCII text in case of type `message`

This is also mentioned in [the docs](https://github.com/websockets/ws/blob/master/doc/ws.md#event-message)