### PR TITLE
Fix `types` field to point to the correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.2",
   "description": "HTTP Man In The Middle (MITM) Proxy",
   "main": "dist/index.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "cross-env TS_NODE_TRANSPILE_ONLY=true TS_NODE_PRETTY=true ts-mocha test/01_proxy.ts --exit",
     "build": "rimraf dist && tsc",


### PR DESCRIPTION
Currently, it points to a non-existent file, which breaks TypeScript.

Should fix #274