### PR TITLE
Use localhost instead of 0.0.0.0 for local connections

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -487,7 +487,7 @@ export class Proxy implements IProxy {
       const conn = net.connect(
         {
           port,
-          host: "0.0.0.0",
+          host: "localhost",
           allowHalfOpen: true,
         },
 


### PR DESCRIPTION
This addresses the issue in #296. Connecting to `0.0.0.0` only works on Linux, it results in `PROXY_TO_PROXY_SOCKET_ERROR on : Error: connect ECONNREFUSED` errors on MacOS and Windows. There's some discussion of this in nodejs/node#14900. This PR changes the target host from `0.0.0.0` to `localhost` in order to make it more cross-platform compatible.