### PR TITLE
Enhanced WebSocket Protocol Handling in Proxy Server Connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "http-mitm-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "http-mitm-proxy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.5",


### PR DESCRIPTION
**Problem:**
Previously, the proxy server's handling of WebSocket connections overlooked the sec-websocket-protocol header, which is critical for specifying subprotocols. For example, when a client requested to establish a WebSocket connection with a specific protocol (e.g., json.reliable.webpubsub.azure.v1 for chatgpt), the proxy would initiate the connection without passing along the requested protocol. This oversight could lead to connection failures or incorrect server behaviors, as the server might not respond with the necessary connection message if the expected protocol was not specified. An example of this issue was observed on the "chatgpt" page, where omitting the protocol led to malfunctioning due to the server's expectation for a specific subprotocol to establish a WebSocket connection.

**Solution:**
The modifications entail capturing the protocol specifications from client requests and incorporating these details into the connection options. Subsequently, these options are passed to the WebSocket constructor, thereby ensuring that the connection process is fully compliant with the protocol requirements.