### PR TITLE
Added trailer support header

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1052,6 +1052,9 @@ export class Proxy implements IProxy {
           return self._onError("ON_RESPONSE_ERROR", ctx, err);
         }
         const servToProxyResp = ctx.serverToProxyResponse!;
+        if(servToProxyResp.headers["trailer"]){
+          servToProxyResp.headers["transfer-encoding"] = "chunked";
+        }
         if (
           self.responseContentPotentiallyModified ||
           ctx.responseContentPotentiallyModified

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-mitm-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "HTTP Man In The Middle (MITM) Proxy",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The basic node.js http server library uses http/1, in this version you have to specify 'transfer-encoding: chunked' for requests that include trailers. In http/2 there is no need to specify this header and most sites have stopped doing it. As a result, when the headers are parsed, our server cannot find the header 'transfer-encoding: chunked' and throws an error