### PR TITLE
Added trailer header support for http/2

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1052,6 +1052,11 @@ export class Proxy implements IProxy {
           return self._onError("ON_RESPONSE_ERROR", ctx, err);
         }
         const servToProxyResp = ctx.serverToProxyResponse!;
+
+        if (servToProxyResp.headers["trailer"]) {
+          servToProxyResp.headers["transfer-encoding"] = "chunked";
+        }
+
         if (
           self.responseContentPotentiallyModified ||
           ctx.responseContentPotentiallyModified


### PR DESCRIPTION
The basic node.js http library uses http/1, so you have to specify 'transfer-encoding: chunked' for requests that include trailers. In http/2 there is no need to specify this header and most sites have stopped doing it. As a result, when the headers are parsed, our server cannot find the header 'transfer-encoding: chunked' and causes an error