### PR TITLE
Add a lookup option to allow users to implement their own DNS resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ __Arguments__
   * forceSNI - force use of [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) by the client. Allow node-http-mitm-proxy to handle all HTTPS requests with a single internal server.
   * httpsPort - The port or named socket for https server to listen on. _(forceSNI must be enabled)_
   * forceChunkedRequest - Setting this option will remove the content-length from the proxy to server request, forcing chunked encoding.
+  * lookup - The DNS lookup function to use. This option can be used to avoid the default synchronous DNS resolution. See [#314](https://github.com/joeferner/node-http-mitm-proxy/issues/314) for details.
 
 __Example__
 

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1150,6 +1150,7 @@ export class Proxy implements IProxy {
         port: hostPort.port,
         headers,
         agent: ctx.isSSL ? self.httpsAgent : self.httpAgent,
+        lookup: this.options.lookup,
       };
       return self._onRequest(ctx, (err) => {
         if (err) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ import type CA from "../lib/ca";
 import type WebSocket from "ws";
 import type { Server } from "https";
 import type { WebSocket as WebSocketType, WebSocketServer } from "ws";
+import type { LookupFunction } from 'net';
 
 export interface IProxyStatic {
   (): IProxy;
@@ -34,6 +35,8 @@ export interface IProxyOptions {
   httpsPort?: number;
   /** - Setting this option will remove the content-length from the proxy to server request, forcing chunked encoding */
   forceChunkedRequest?: boolean;
+  /** - The DNS lookup function to use. This option can be used to avoid the default synchronous DNS resolution. See #314 for details. */
+  lookup?: LookupFunction;
 }
 
 export interface IProxySSLServer {
@@ -306,6 +309,7 @@ export type IContext = ICallbacks &
       port: string | number | null | undefined;
       headers: { [key: string]: string };
       agent: http.Agent;
+      lookup: LookupFunction | undefined;
     };
 
     onRequestHandlers: OnRequestParams[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "http-mitm-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "http-mitm-proxy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.5",


### PR DESCRIPTION
Fix #314.

Users can provide a `lookup` option to replace Node.js's internal default synchronous DNS resolution, significantly improving performance in cases where DNS resolution might time out.

The `dns.resolve()` methods are asynchronous but behave slightly differently from the default `dns.lookup()`. For example, `dns.resolve()` does not follow the local hosts file. Considering these behavioral differences, an option is provided for users to pass in, rather than modifying it internally.

Reference Information: #314 and [Nodejs DNS docs](https://nodejs.org/docs/latest/api/dns.html#dns_implementation_considerations)