### PR TITLE
Fix proxy-to-proxy connections when bound to ipv6 address

### DIFF
--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -66,6 +66,7 @@ export class Proxy implements IProxy {
   httpAgent!: http.Agent;
   httpHost?: string;
   httpPort!: number;
+  httpProxyToProxyHost?: string;
   httpServer: HTTPServer | undefined;
   httpsAgent!: https.Agent;
   httpsPort?: number;
@@ -120,6 +121,7 @@ export class Proxy implements IProxy {
     this.options = options || {};
     this.httpPort = options.port || options.port === 0 ? options.port : 8080;
     this.httpHost = options.host || "localhost";
+    this.httpProxyToProxyHost = options.proxyToProxyHost || "0.0.0.0";
     this.timeout = options.timeout || 0;
     this.keepAlive = !!options.keepAlive;
     this.httpAgent =
@@ -487,7 +489,7 @@ export class Proxy implements IProxy {
       const conn = net.connect(
         {
           port,
-          host: "0.0.0.0",
+          host: self.httpProxyToProxyHost,
           allowHalfOpen: true,
         },
 

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -66,7 +66,6 @@ export class Proxy implements IProxy {
   httpAgent!: http.Agent;
   httpHost?: string;
   httpPort!: number;
-  httpProxyToProxyHost?: string;
   httpServer: HTTPServer | undefined;
   httpsAgent!: https.Agent;
   httpsPort?: number;
@@ -121,7 +120,6 @@ export class Proxy implements IProxy {
     this.options = options || {};
     this.httpPort = options.port || options.port === 0 ? options.port : 8080;
     this.httpHost = options.host || "localhost";
-    this.httpProxyToProxyHost = options.proxyToProxyHost || "0.0.0.0";
     this.timeout = options.timeout || 0;
     this.keepAlive = !!options.keepAlive;
     this.httpAgent =
@@ -485,11 +483,15 @@ export class Proxy implements IProxy {
 
     socket.pause();
     function makeConnection(port: number) {
-      // open a TCP connection to the remote host
+      // open a TCP connection to the local server
+      // We connect to the same address that the server is bound to.
+      // This is important if, for example, we use 'localhost' which might resolve to ::1 or 127.0.0.1.
+      // If we bound to ::1 and we try to connect to 127.0.0.1, the connection will fail.
+      const host = (self.httpServer!.address() as AddressInfo).address;
       const conn = net.connect(
         {
           port,
-          host: self.httpProxyToProxyHost,
+          host,
           allowHalfOpen: true,
         },
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,8 @@ export interface IProxyOptions {
   port?: number;
   /**host - The hostname or local address to listen on.*/
   host?: string;
+  /**proxyToProxyHost - The hostname or local address to bind the proxy to proxy socket.*/
+  proxyToProxyHost?: string;
   /** - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')*/
   sslCaDir?: string;
   /**  - enable HTTP persistent connection*/

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,8 +18,6 @@ export interface IProxyOptions {
   port?: number;
   /**host - The hostname or local address to listen on.*/
   host?: string;
-  /**proxyToProxyHost - The hostname or local address to bind the proxy to proxy socket.*/
-  proxyToProxyHost?: string;
   /** - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')*/
   sslCaDir?: string;
   /**  - enable HTTP persistent connection*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mablhq/http-mitm-proxy",
-  "version": "1.1.0-mabl",
+  "version": "1.1.0",
   "description": "HTTP Man In The Middle (MITM) Proxy",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "http-mitm-proxy",
-  "version": "1.1.0",
+  "name": "@mablhq/http-mitm-proxy",
+  "version": "1.1.0-mabl",
   "description": "HTTP Man In The Middle (MITM) Proxy",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mablhq/http-mitm-proxy",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "HTTP Man In The Middle (MITM) Proxy",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
If the proxy is bound to an IPv6 address, like `::1`, it fails to connect to its SSL helper server because  it uses a hard-coded `0.0.0.0` which is the wrong address family (IPv6), so this results in it attempting to connect to `127.0.0.1` and failing.